### PR TITLE
loosen JuMP and MPB bounds slightly

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.6
-JuMP 0.18.0
+JuMP 0.17
 ConditionalJuMP 0.0.3
 Memento 0.3.1
 AutoHashEquals 0.1.2
 MAT 0.4.0
-MathProgBase 0.7.0
+MathProgBase 0.6


### PR DESCRIPTION
I was having some trouble installing this because it requires the latest versions of JuMP and MathProgBase, while some of my other packages don't yet support those versions. I just verified that the tests work with JuMP 0.17 and MathProgBase 0.6, so I've loosened the required bounds slightly. 