### PR TITLE
find_adversarial_example: enable searching for worst adversarial example

### DIFF
--- a/src/MIPVerify.jl
+++ b/src/MIPVerify.jl
@@ -15,6 +15,7 @@ const dependencies_path = joinpath(Pkg.dir("MIPVerify"), "deps")
 export find_adversarial_example, frac_correct, interval_arithmetic, lp, mip
 
 @enum TighteningAlgorithm interval_arithmetic=1 lp=2 mip=3
+@enum AdversarialExampleObjective closest=1 worst=2
 const DEFAULT_TIGHTENING_ALGORITHM = mip
 
 include("net_components.jl")
@@ -94,7 +95,8 @@ function find_adversarial_example(
     tightening_algorithm::TighteningAlgorithm = DEFAULT_TIGHTENING_ALGORITHM,
     tightening_solver::MathProgBase.SolverInterface.AbstractMathProgSolver = get_default_tightening_solver(main_solver),
     cache_model::Bool = true,
-    solve_if_predicted_in_targeted = true
+    solve_if_predicted_in_targeted = true,
+    adversarial_example_objective::AdversarialExampleObjective = closest
     )::Dict
 
     total_time = @elapsed begin
@@ -118,14 +120,22 @@ function find_adversarial_example(
                 get_model(nn, input, pp, tightening_solver, tightening_algorithm, rebuild, cache_model)
             )
             m = d[:Model]
+            
+            if adversarial_example_objective == closest
+                set_max_indexes(d[:Model], d[:Output], d[:TargetIndexes], tolerance=tolerance)
 
-            set_max_indexes(d[:Model], d[:Output], d[:TargetIndexes], tolerance=tolerance)
-
-            # Set perturbation objective
-            # NOTE (vtjeng): It is important to set the objective immediately before we carry out
-            # the solve. Functions like `set_max_indexes` can modify the objective.
+                # Set perturbation objective
+                # NOTE (vtjeng): It is important to set the objective immediately before we carry out
+                # the solve. Functions like `set_max_indexes` can modify the objective.
+                @objective(m, Min, get_norm(norm_order, d[:Perturbation]))
+            elseif adversarial_example_objective == worst
+                (maximum_target_var, other_vars) = get_vars_for_max_index(d[:Output], d[:TargetIndexes], tolerance=tolerance)
+                maximum_other_var = maximum_ge(other_vars)
+                @objective(m, Max, maximum_target_var - maximum_other_var)    
+            else
+                error("Unknown adversarial_example_objective $adversarial_example_objective")
+            end
             setsolver(d[:Model], main_solver)
-            @objective(m, Min, get_norm(norm_order, d[:Perturbation]))
             d[:SolveStatus] = solve(m)
         end
     end

--- a/src/batch_processing_helpers.jl
+++ b/src/batch_processing_helpers.jl
@@ -262,7 +262,8 @@ function batch_find_untargeted_attack(
     tightening_algorithm::MIPVerify.TighteningAlgorithm = DEFAULT_TIGHTENING_ALGORITHM,
     tightening_solver::MathProgBase.SolverInterface.AbstractMathProgSolver = MIPVerify.get_default_tightening_solver(main_solver),
     cache_model = true,
-    solve_if_predicted_in_targeted = true
+    solve_if_predicted_in_targeted = true,
+    adversarial_example_objective::AdversarialExampleObjective = closest
     )::Void
     
     verify_target_indices(target_indices, dataset)
@@ -274,7 +275,7 @@ function batch_find_untargeted_attack(
             info(MIPVerify.LOGGER, "Working on index $(sample_number)")
             input = MIPVerify.get_image(dataset.images, sample_number)
             true_one_indexed_label = MIPVerify.get_label(dataset.labels, sample_number) + 1
-            d = find_adversarial_example(nn, input, true_one_indexed_label, main_solver, invert_target_selection = true, pp=pp, norm_order=norm_order, tolerance=tolerance, rebuild=rebuild, tightening_algorithm = tightening_algorithm, tightening_solver = tightening_solver, cache_model=cache_model, solve_if_predicted_in_targeted=solve_if_predicted_in_targeted)
+            d = find_adversarial_example(nn, input, true_one_indexed_label, main_solver, invert_target_selection = true, pp=pp, norm_order=norm_order, tolerance=tolerance, rebuild=rebuild, tightening_algorithm = tightening_algorithm, tightening_solver = tightening_solver, cache_model=cache_model, solve_if_predicted_in_targeted=solve_if_predicted_in_targeted, adversarial_example_objective=adversarial_example_objective)
 
             save_to_disk(sample_number, main_path, results_dir, summary_file_path, d, solve_if_predicted_in_targeted)
         end

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -443,7 +443,6 @@ function get_target_indexes(
 end
 
 function get_vars_for_max_index(
-    model::Model,
     xs::Array{<:JuMPLinearType, 1},
     target_indexes::Array{<:Integer, 1};
     tolerance::Real = 0)
@@ -457,7 +456,7 @@ function get_vars_for_max_index(
         target_vars[1] :    
         MIPVerify.maximum(target_vars)
 
-    @constraint(model, other_vars - maximum_target_var .<= -tolerance)
+    return (maximum_target_var, other_vars)
 end
 
 """
@@ -473,14 +472,7 @@ function set_max_indexes(
     target_indexes::Array{<:Integer, 1};
     tolerance::Real = 0)
 
-    @assert length(xs) >= 1
-
-    target_vars = xs[Bool[i∈target_indexes for i = 1:length(xs)]]
-    other_vars = xs[Bool[i∉target_indexes for i = 1:length(xs)]]
-
-    maximum_target_var = length(target_vars) == 1 ?
-        target_vars[1] :    
-        MIPVerify.maximum(target_vars)
+    (maximum_target_var, other_vars) = get_vars_for_max_index(xs, target_indexes, tolerance)
 
     @constraint(model, other_vars - maximum_target_var .<= -tolerance)
 end


### PR DESCRIPTION
**tl;dr:** Use `adversarial_example_objective = MIPVerify.worst` as parameter in `find_adversarial_example` or `batch_find_untargeted_attack` to find the worst adversarl example.

---------------

`find_adversarial_example` previously searched for the closest adversarial example. We now enable searching for the worst adversarial example via the optional parameter `adversarial_example_objective` in `find_adversarial_example`. 

When `adversarial_example_objective = MIPVerify.worst`, the optimizer will attempt to find the adversarial example where the difference between the _maximum target activation_ [1] and the _maximum off-target activation_ [2] is maximized. (Note that when `adversarial_example_objective=MIPVerify.worst`, the `norm_order` parameter specified is ignored.) The objective value is **positive** if the maximum target activation exceeds the maximum off-target activation.

The same parameter is available in `batch_find_untargeted_attack`, which is how we expect users to call the function.

## Testing
This has been sanity checked on `MNIST.WK17a_linf0.1_authors`, but no test code has been written.

## Additional Release Notes
In the summary `csv` files, If `ObjectiveValue` and `ObjectiveBound` differ significantly, the `ObjectiveBound` is more reliable. (There seems to be an issue where the `JuMP` is not accessing the final objective value found by the solve process).

[1] maximum activation in the target adversarial categories
[2] maximum activation in all other categories