### PR TITLE
layers: fix memory issue in Conv2d and Linear

### DIFF
--- a/src/net_components/layers/conv2d.jl
+++ b/src/net_components/layers/conv2d.jl
@@ -156,5 +156,4 @@ function conv2d(
     return output
 end
 
-(p::Conv2d)(x::Array{<:Real, 4}) = conv2d(x, p)
-(p::Conv2d)(x::Array{<:JuMPLinearType, 4}) = conv2d(x, p)
+(p::Conv2d)(x::Array{<:JuMPReal, 4}) = conv2d(x, p)

--- a/src/net_components/layers/conv2d.jl
+++ b/src/net_components/layers/conv2d.jl
@@ -147,6 +147,9 @@ function conv2d(
             end
         end
         s += params.bias[i_4]
+        if T<:JuMPLinearType
+            ConditionalJuMP.simplify!(s)
+        end
         (@nref 4 output i) = s
     end
 
@@ -154,4 +157,4 @@ function conv2d(
 end
 
 (p::Conv2d)(x::Array{<:Real, 4}) = conv2d(x, p)
-(p::Conv2d)(x::Array{<:JuMPLinearType, 4}) = ConditionalJuMP.simplify!.(conv2d(x, p))
+(p::Conv2d)(x::Array{<:JuMPLinearType, 4}) = conv2d(x, p)

--- a/src/net_components/layers/linear.jl
+++ b/src/net_components/layers/linear.jl
@@ -60,5 +60,14 @@ end
 
 (p::Linear)(x::Array{<:JuMPReal}) = "Linear() layers work only on one-dimensional input. You likely forgot to add a Flatten() layer before your first linear layer." |> ArgumentError |> throw
 
+function matmul_wrapped(
+    x::Array{<:JuMPLinearType, 1},
+    p::Linear)
+    info(MIPVerify.LOGGER, "Applying $p ... ")
+    o = matmul(x, p)
+    foreach(ConditionalJuMP.simplify!, o)
+    o
+end
+
 (p::Linear)(x::Array{<:Real, 1}) = matmul(x, p)
-(p::Linear)(x::Array{<:JuMPLinearType, 1}) = (info(MIPVerify.LOGGER, "Applying $p ... "); ConditionalJuMP.simplify!.(matmul(x, p)))
+(p::Linear)(x::Array{<:JuMPLinearType, 1}) = matmul_wrapped(x, p)

--- a/src/net_components/layers/linear.jl
+++ b/src/net_components/layers/linear.jl
@@ -53,21 +53,43 @@ Computes the result of pre-multiplying `x` by the transpose of `params.matrix` a
 `params.bias`.
 """
 function matmul(
-    x::Array{<:JuMPReal, 1}, 
+    x::Array{<:Real, 1}, 
     params::Linear)
     return params.matrix.'*x .+ params.bias
 end
 
-(p::Linear)(x::Array{<:JuMPReal}) = "Linear() layers work only on one-dimensional input. You likely forgot to add a Flatten() layer before your first linear layer." |> ArgumentError |> throw
+"""
+$(SIGNATURES)
 
-function matmul_wrapped(
-    x::Array{<:JuMPLinearType, 1},
-    p::Linear)
-    info(MIPVerify.LOGGER, "Applying $p ... ")
-    o = matmul(x, p)
-    foreach(ConditionalJuMP.simplify!, o)
-    o
+Computes the result of pre-multiplying `x` by the transpose of `params.matrix` and adding
+`params.bias`. We write the computation out by hand when working with `JuMPLinearType`
+so that we are able to simplify the output as the computation is carried out.
+"""
+function matmul(
+    x::Array{T, 1}, 
+    params::Linear{U, V}) where {T<:JuMPLinearType, U<:Real, V<:Real}
+    info(MIPVerify.LOGGER, "Applying $params ... ")
+    (matrix_height, matrix_width) = size(params.matrix)
+    (input_height, ) = size(x)
+    @assert(matrix_height == input_height,
+        "Number of values in input, $input_height, does not match number of values, $matrix_height that Linear operates on."
+    )
+    W = Base.promote_op(+, V, Base.promote_op(*, T, U))
+    output = Array{W}(matrix_width)
+
+    for i in 1:matrix_width
+        s::W = 0
+        for j in 1:matrix_height
+            s = increment!(s, x[j], params.matrix[j, i])
+        end
+        s += params.bias[i]
+        ConditionalJuMP.simplify!(s)
+        output[i] = s
+    end
+
+    return output
 end
 
-(p::Linear)(x::Array{<:Real, 1}) = matmul(x, p)
-(p::Linear)(x::Array{<:JuMPLinearType, 1}) = matmul_wrapped(x, p)
+(p::Linear)(x::Array{<:JuMPReal}) = "Linear() layers work only on one-dimensional input. You likely forgot to add a Flatten() layer before your first linear layer." |> ArgumentError |> throw
+
+(p::Linear)(x::Array{<:JuMPReal, 1}) = matmul(x, p)


### PR DESCRIPTION
We were previously carrying out simplification of the output of `Conv2d` and `Linear` layers _after_ the entire array of `JuMPAffExpr` had been created. We now do so within the loop, reducing the amount of memory needed.