### PR TITLE
find_adversarial_example: solver does not support getsolvetime

### DIFF
--- a/src/MIPVerify.jl
+++ b/src/MIPVerify.jl
@@ -136,7 +136,12 @@ function find_adversarial_example(
                 error("Unknown adversarial_example_objective $adversarial_example_objective")
             end
             setsolver(d[:Model], main_solver)
-            d[:SolveStatus] = solve(m)
+            solve_time = @elapsed begin 
+                d[:SolveStatus] = solve(m)
+            end
+            if d[:SolveTime] == -1
+                d[:Solvetime] = solve_time
+            end
         end
     end
     d[:TotalTime] = total_time

--- a/src/MIPVerify.jl
+++ b/src/MIPVerify.jl
@@ -122,7 +122,7 @@ function find_adversarial_example(
             m = d[:Model]
             
             if adversarial_example_objective == closest
-                set_max_indexes(d[:Model], d[:Output], d[:TargetIndexes], tolerance=tolerance)
+                set_max_indexes(m, d[:Output], d[:TargetIndexes], tolerance=tolerance)
 
                 # Set perturbation objective
                 # NOTE (vtjeng): It is important to set the objective immediately before we carry out
@@ -135,15 +135,20 @@ function find_adversarial_example(
             else
                 error("Unknown adversarial_example_objective $adversarial_example_objective")
             end
-            setsolver(d[:Model], main_solver)
+            setsolver(m, main_solver)
             solve_time = @elapsed begin 
                 d[:SolveStatus] = solve(m)
             end
-            if d[:SolveTime] == -1
-                d[:Solvetime] = solve_time
+            d[:SolveTime] = try
+                getsolvetime(m)
+            catch err
+                # CBC solver, used for testing, does not implement `getsolvetime`.
+                isa(err, MethodError) || rethrow(err)
+                solve_time
             end
         end
     end
+    
     d[:TotalTime] = total_time
     return d
 end

--- a/src/batch_processing_helpers.jl
+++ b/src/batch_processing_helpers.jl
@@ -23,13 +23,7 @@ end
 function extract_results_for_save(d::Dict)::Dict
     m = d[:Model]
     r = Dict()
-    # CBC solver, used for testing, does not implement `getsolvetime`.
-    r[:SolveTime] = try
-        getsolvetime(m)
-    catch err
-        isa(err, MethodError) || rethrow(err)
-        -1
-    end
+    r[:SolveTime] = d[:SolveTime]
     r[:ObjectiveBound] = getobjbound(m)
     r[:ObjectiveValue] = getobjectivevalue(m)
     r[:TargetIndexes] = d[:TargetIndexes]


### PR DESCRIPTION
Some solvers (for exampe, `Cbc`) do not support `getsolvetime`. Previously, we used to specify a default `:SolveTime` of `-1`; we fix this by actually timing the solve process.