### PR TITLE
Slight refactor and improve test coverage.

### DIFF
--- a/src/MIPVerify.jl
+++ b/src/MIPVerify.jl
@@ -92,7 +92,7 @@ function find_adversarial_example(
     pp::PerturbationFamily = UnrestrictedPerturbationFamily(),
     norm_order::Real = 1,
     tolerance::Real = 0.0,
-    adversarial_example_objective::AdversarialExampleObjective = closest
+    adversarial_example_objective::AdversarialExampleObjective = closest,
     tightening_algorithm::TighteningAlgorithm = DEFAULT_TIGHTENING_ALGORITHM,
     tightening_solver::MathProgBase.SolverInterface.AbstractMathProgSolver = get_default_tightening_solver(main_solver),
     rebuild::Bool = false,

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -380,7 +380,7 @@ Only use when you are minimizing over the output in the objective.
 
 NB: If all of xs are constant, we simply return the largest of them.
 """
-function maximum_ge(xs::AbstractArray{T})::JuMP.Variable where {T<:JuMPLinearType}
+function maximum_ge(xs::AbstractArray{T})::JuMPLinearType where {T<:JuMPLinearType}
     @assert length(xs)>0
     if all(is_constant.(xs))
         return maximum_of_constants(xs)
@@ -444,19 +444,18 @@ end
 
 function get_vars_for_max_index(
     xs::Array{<:JuMPLinearType, 1},
-    target_indexes::Array{<:Integer, 1},
-    tolerance::Real)
+    target_indexes::Array{<:Integer, 1})
 
     @assert length(xs) >= 1
 
     target_vars = xs[Bool[i∈target_indexes for i = 1:length(xs)]]
-    other_vars = xs[Bool[i∉target_indexes for i = 1:length(xs)]]
+    nontarget_vars = xs[Bool[i∉target_indexes for i = 1:length(xs)]]
 
     maximum_target_var = length(target_vars) == 1 ?
         target_vars[1] :    
         MIPVerify.maximum(target_vars)
 
-    return (maximum_target_var, other_vars)
+    return (maximum_target_var, nontarget_vars)
 end
 
 """
@@ -472,7 +471,7 @@ function set_max_indexes(
     target_indexes::Array{<:Integer, 1};
     tolerance::Real = 0)
 
-    (maximum_target_var, other_vars) = get_vars_for_max_index(xs, target_indexes, tolerance)
+    (maximum_target_var, nontarget_vars) = get_vars_for_max_index(xs, target_indexes)
 
-    @constraint(model, other_vars - maximum_target_var .<= -tolerance)
+    @constraint(model, nontarget_vars - maximum_target_var .<= -tolerance)
 end

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -37,7 +37,7 @@ end
 
 """
 Tests the `find_adversarial_example` function.
-  - If `x0` is already classified in the target label, `expected_objective_value`
+  - If `input` is already classified in the target label, `expected_objective_value`
     should be 0.
   - If there is no adversarial example for the specified parameters, 
     `expected_objective_value` should be NaN.
@@ -47,18 +47,19 @@ Tests the `find_adversarial_example` function.
 """
 function test_find_adversarial_example(
     nn::NeuralNet, 
-    x0::Array{<:Real, N}, 
+    input::Array{<:Real, N}, 
     target_selection::Union{Integer, Array{<:Integer, 1}}, 
     pp::PerturbationFamily, 
     norm_order::Real,
     tolerance::Real, 
-    expected_objective_value::Real,
+    expected_objective_value::Real;
+    invert_target_selection::Bool = false,
     ) where {N} 
     d = find_adversarial_example(
-        nn, x0, target_selection, get_main_solver(),
+        nn, input, target_selection, get_main_solver(),
         pp = pp, norm_order = norm_order, tolerance = tolerance, rebuild=false, 
-        tightening_solver=get_tightening_solver(), tightening_algorithm=TEST_DEFAULT_TIGHTENING_ALGORITHM)
-    println(d[:SolveStatus])
+        tightening_solver=get_tightening_solver(), tightening_algorithm=TEST_DEFAULT_TIGHTENING_ALGORITHM, 
+        invert_target_selection=invert_target_selection)
     if d[:SolveStatus] == :Infeasible || d[:SolveStatus] == :InfeasibleOrUnbounded
         @test isnan(expected_objective_value)
     else
@@ -77,7 +78,7 @@ function test_find_adversarial_example(
 end
 
 """
-Runs tests on the neural net described by `nn` for input `x0` and the objective values
+Runs tests on the neural net described by `nn` for input `input` and the objective values
 indicated in `expected objective values`.
 
 # Arguments
@@ -88,14 +89,14 @@ indicated in `expected objective values`.
 """
 function batch_test_adversarial_example(
     nn::NeuralNet, 
-    x0::Array{<:Real, N},
+    input::Array{<:Real, N},
     test_cases::Array
 ) where {N}
     for (test_params, expected_objective_value) in test_cases
         (target_selection, pp, norm_order, tolerance) = test_params
         @testset "target labels = $target_selection, $(string(pp)) perturbation, norm order = $norm_order, tolerance = $tolerance" begin
             test_find_adversarial_example(
-                nn, x0, 
+                nn, input, 
                 target_selection, pp, norm_order, tolerance, expected_objective_value)
             end
         end

--- a/test/integration/sequential/generated_weights/conv+fc+softmax.jl
+++ b/test/integration/sequential/generated_weights/conv+fc+softmax.jl
@@ -25,7 +25,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
     l2_width = l1_height
 
     ### Choosing data to be used
-    x0 = gen_array(
+    input = gen_array(
         (batch, c1_in_height, c1_in_width, c1_in_channels), 
         0, 1
     )
@@ -60,7 +60,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
             ((3, pp_blur, 1, 0), NaN),
         ]
 
-        TestHelpers.batch_test_adversarial_example(nn, x0, test_cases)
+        TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
     end
 
     @testset "UnrestrictedPerturbationFamily" begin
@@ -71,7 +71,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
                 ((2, pp_unrestricted, 1, 0), 9.2825418),
             ]
 
-            TestHelpers.batch_test_adversarial_example(nn, x0, test_cases)
+            TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
         end
 
         @testset "Minimizing lInf norm" begin
@@ -81,7 +81,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
                 ((3, pp_unrestricted, Inf, 0), 0.5045819),
             ]
 
-            TestHelpers.batch_test_adversarial_example(nn, x0, test_cases)
+            TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
         end
 
         @testset "Increasing margin increases required distance" begin
@@ -89,7 +89,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
                 ((2, pp_unrestricted, 1, 0.1), 9.5642628),
             ]
 
-            TestHelpers.batch_test_adversarial_example(nn, x0, test_cases)
+            TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
         end
 
         @testset "With multiple target labels specified, minimum target label found" begin
@@ -97,7 +97,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
                 (([2, 3], pp_unrestricted, Inf, 0), 0.4347241),
             ]
 
-            TestHelpers.batch_test_adversarial_example(nn, x0, test_cases)
+            TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
         end
     end
 
@@ -107,6 +107,6 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
             ((2, LInfNormBoundedPerturbationFamily(0.435), Inf, 0), 0.4347241),  # restricting maximum perturbation to above minimum distance does not affect optimal value of problem
         ]
 
-        TestHelpers.batch_test_adversarial_example(nn, x0, test_cases)
+        TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
     end
 end

--- a/test/integration/sequential/generated_weights/mfc+mfc+softmax.jl
+++ b/test/integration/sequential/generated_weights/mfc+mfc+softmax.jl
@@ -4,10 +4,10 @@ using MIPVerify: UnrestrictedPerturbationFamily, LInfNormBoundedPerturbationFami
 @isdefined(TestHelpers) || include("../../../TestHelpers.jl")
 
 @testset "mfc + mfc + softmax" begin
-    x0 = gen_array((1, 4, 8, 1), 0, 1)
+    input = gen_array((1, 4, 8, 1), 0, 1)
 
     l1_height = 16
-    l1_width = length(x0)
+    l1_width = length(input)
     l1_kernel = gen_array((l1_width, l1_height), -1, 1)
     l1_bias = gen_array((l1_height,), -1, 1)
 
@@ -49,6 +49,6 @@ using MIPVerify: UnrestrictedPerturbationFamily, LInfNormBoundedPerturbationFami
             ((1, LInfNormBoundedPerturbationFamily(0.085), Inf, 0) => 0.08112308),
         ]
 
-        TestHelpers.batch_test_adversarial_example(nn, x0, test_cases)
+        TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
     end
 end

--- a/test/integration/sequential/trained_weights.jl
+++ b/test/integration/sequential/trained_weights.jl
@@ -2,4 +2,5 @@ using Test
 
 @testset "trained_weights" begin
     include("trained_weights/MNIST.n1.jl")
+    include("trained_weights/MNIST.WK17a_linf0.1_authors.jl")
 end

--- a/test/integration/sequential/trained_weights/MNIST.WK17a_linf0.1_authors.jl
+++ b/test/integration/sequential/trained_weights/MNIST.WK17a_linf0.1_authors.jl
@@ -1,0 +1,29 @@
+using Test
+using MIPVerify
+using MIPVerify: LInfNormBoundedPerturbationFamily
+using MIPVerify: get_example_network_params, read_datasets, get_image, get_label
+@isdefined(TestHelpers) || include("../../../TestHelpers.jl")
+
+@testset "MNIST.WK17a_linf0.1_authors" begin
+    nn = get_example_network_params("MNIST.WK17a_linf0.1_authors")
+    mnist = read_datasets("mnist")
+
+    test_cases = [
+        (1, NaN),
+        (2, NaN),
+        (9, 0.0940014207),
+        (248, 0),
+    ]
+
+    for test_case in test_cases
+        (index, expected_objective_value) = test_case
+        @testset "Sample $index (1-indexed) with expected objective value $expected_objective_value" begin
+            input = get_image(mnist.test.images, index)
+            label = get_label(mnist.test.labels, index)
+            TestHelpers.test_find_adversarial_example(
+                nn, input, label+1, LInfNormBoundedPerturbationFamily(0.1), Inf, 0, expected_objective_value, 
+                invert_target_selection=true
+            )
+        end
+    end
+end

--- a/test/integration/sequential/trained_weights/MNIST.n1.jl
+++ b/test/integration/sequential/trained_weights/MNIST.n1.jl
@@ -12,7 +12,7 @@ using MIPVerify: get_example_network_params, read_datasets, get_image
     pp_unrestricted = UnrestrictedPerturbationFamily()
 
     sample_index = 1
-    x0 = get_image(mnist.test.images, sample_index)
+    input = get_image(mnist.test.images, sample_index)
 
     @testset "Basic integration test demonstrating success on trained (non-robust) network." begin
         test_cases = [
@@ -21,7 +21,7 @@ using MIPVerify: get_example_network_params, read_datasets, get_image
             ((10, LInfNormBoundedPerturbationFamily(0.05), Inf, 0), 0.0460847),
         ]
 
-        TestHelpers.batch_test_adversarial_example(nn, x0, test_cases)
+        TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
     end
     
 end


### PR DESCRIPTION
  + Reorder arguments in `find_adversarial_example`
  + Standardize naming convention for input: `x0` -> `input`
  + Remove unused `tolerance` from `get_vars_for_max_index`
  + Improve test coverage (and fix bug in `maximum_ge` where the method signature was overly restrictive)