### PR TITLE
Make SAME padding computation match TensorFlow

### DIFF
--- a/src/net_components/layers/conv2d.jl
+++ b/src/net_components/layers/conv2d.jl
@@ -127,8 +127,11 @@ function conv2d(
     # cell at which correlation is being calculated. Note that tensorflow
     # chooses a specific convention for a dimension with even size which we
     # replicate here.
-    filter_height_offset = round(Int, filter_height/2, RoundUp)
-    filter_width_offset = round(Int, filter_width/2, RoundUp)
+    pad_along_height = max((out_height - 1)*stride + filter_height - in_height, 0)
+    pad_along_width = max((out_width - 1)*stride + filter_width - in_width, 0)
+    filter_height_offset = round(Int, pad_along_height/2, RoundDown)
+    filter_width_offset = round(Int, pad_along_width/2, RoundDown)
+    
     W = Base.promote_op(+, V, Base.promote_op(*, T, U))
     output = Array{W}(undef, output_size)
 
@@ -136,8 +139,8 @@ function conv2d(
         s::W = 0
         @nloops 4 j filter begin
             if i_4 == j_4
-                x = (i_2-1)*stride+1 + j_1 - filter_height_offset
-                y = (i_3-1)*stride+1 + j_2 - filter_width_offset
+                x = (i_2-1)*stride + j_1 - filter_height_offset
+                y = (i_3-1)*stride + j_2 - filter_width_offset
                 if x > 0 && y > 0 && x<=in_height && y<=in_width
                     # Doing bounds check to make sure that we stay within bounds
                     # for input. This effectively zero-pads the input.

--- a/test/net_components/layers/conv2d.jl
+++ b/test/net_components/layers/conv2d.jl
@@ -115,4 +115,92 @@ using MIPVerify: check_size, increment!
             @test solve_output≈true_output
         end
     end
+
+    @testset "conv2d with non-unit stride" begin
+        input_size = (1, 6, 6, 2)
+        input = reshape(collect(1:prod(input_size)), input_size) .- 36
+        filter_size = (3, 3, 2, 1)
+        filter = reshape(collect(1:prod(filter_size)), filter_size) .- 9
+        bias_size = (1, )
+        bias = [1]
+        stride = 2
+        true_output_raw = [
+            1597  1615  1120;
+            1705  1723  1120;
+            903   879   513 ;
+        ]
+        true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+        p = Conv2d(filter, bias, stride)
+        @testset "Numerical Input, Numerical Layer Parameters" begin
+            evaluated_output = MIPVerify.conv2d(input, p)
+            @test evaluated_output == true_output
+        end
+        @testset "Numerical Input, Variable Layer Parameters" begin
+            m = TestHelpers.get_new_model()
+            filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+            bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+            p_v = Conv2d(filter_v, bias_v, stride)
+            output_v = MIPVerify.conv2d(input, p_v)
+            @constraint(m, output_v .== true_output)
+            solve(m)
+
+            p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride)
+            solve_output = MIPVerify.conv2d(input, p_solve)
+            @test solve_output≈true_output
+        end
+        @testset "Variable Input, Numerical Layer Parameters" begin
+            m = TestHelpers.get_new_model()
+            input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+            output_v = MIPVerify.conv2d(input_v, p)
+            @constraint(m, output_v .== true_output)
+            solve(m)
+
+            solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+            @test solve_output≈true_output
+        end
+    end
+
+    @testset "conv2d with stride 2, odd input shape with even filter shape" begin
+        input_size = (1, 5, 5, 2)
+        input = reshape(collect(1:prod(input_size)), input_size) .- 25
+        filter_size = (4, 4, 2, 1)
+        filter = reshape(collect(1:prod(filter_size)), filter_size) .- 16
+        bias_size = (1, )
+        bias = [1]
+        stride = 2
+        true_output_raw = [
+            1756  2511  1310;
+            3065  4097  1969;
+            1017  1225  501 ;
+        ]
+        true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+        p = Conv2d(filter, bias, stride)
+        @testset "Numerical Input, Numerical Layer Parameters" begin
+            evaluated_output = MIPVerify.conv2d(input, p)
+            @test evaluated_output == true_output
+        end
+        @testset "Numerical Input, Variable Layer Parameters" begin
+            m = TestHelpers.get_new_model()
+            filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+            bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+            p_v = Conv2d(filter_v, bias_v, stride)
+            output_v = MIPVerify.conv2d(input, p_v)
+            @constraint(m, output_v .== true_output)
+            solve(m)
+
+            p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride)
+            solve_output = MIPVerify.conv2d(input, p_solve)
+            @test solve_output≈true_output
+        end
+        @testset "Variable Input, Numerical Layer Parameters" begin
+            m = TestHelpers.get_new_model()
+            input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+            output_v = MIPVerify.conv2d(input_v, p)
+            @constraint(m, output_v .== true_output)
+            solve(m)
+
+            solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+            @test solve_output≈true_output
+        end
+    end
 end


### PR DESCRIPTION
The top and left pad length computations do not match those of Tensorflow for some use cases. The current implementation assumes that the left and right, and top and bottom pads must be the same, but in some cases they can be different, in which case the left and top pad lengths should be shorter than the right and bottom pads. This can occur when the stride is greater than 1. For example, if the input size is (1, 6, 6, 2), the filter size is (3, 3, 2, 1), and the stride is 2, then the expected output size for SAME padding is (1, 3, 3, 1), which means the top and left pads should be length 0, while the bottom and right pads should be length 1. The existing implementation computes top and left pads of length 1.

This pull request modifies the computation of top and left pad lengths to be consistent with Tensorflow. It also adds 2 test cases to test convolutions with strides of length 2.