### PR TITLE
Reduce amount of time tests take to run

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ MAT = "≥ 0.5.0"
 MathProgBase = "≥ 0.7.7"
 Memento = "≥ 0.12.1"
 ProgressMeter = "≥ 1.0.0"
+TimerOutputs = "≥ 0.5.3"
 julia = "≥ 1.0.0"
 
 [deps]
@@ -36,6 +37,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
-test = ["Statistics", "Test", "Cbc"]
+test = ["Statistics", "Test", "Cbc", "TimerOutputs"]

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 Cbc 0.3.2
+TimerOutputs v0.5.3

--- a/test/batch_processing_helpers.jl
+++ b/test/batch_processing_helpers.jl
@@ -1,7 +1,7 @@
 
 using Test
 
-@testset "batch_processing_helpers.jl" begin
+@timed_testset "batch_processing_helpers/" begin
     include("batch_processing_helpers/unit.jl")
     include("batch_processing_helpers/integration.jl")
 end

--- a/test/batch_processing_helpers/integration.jl
+++ b/test/batch_processing_helpers/integration.jl
@@ -3,7 +3,7 @@ using MIPVerify
 using MIPVerify: LInfNormBoundedPerturbationFamily
 @isdefined(TestHelpers) || include("../TestHelpers.jl")
 
-@testset "integration" begin
+@timed_testset "integration.jl" begin
     mnist = read_datasets("MNIST")
     nn_wk17a = get_example_network_params("MNIST.WK17a_linf0.1_authors")
     @testset "batch_find_untargeted_attack" begin 

--- a/test/batch_processing_helpers/unit.jl
+++ b/test/batch_processing_helpers/unit.jl
@@ -4,7 +4,7 @@ using MIPVerify: BatchRunParameters, UnrestrictedPerturbationFamily, mkpath_if_n
 using MIPVerify: run_on_sample_for_untargeted_attack, run_on_sample_for_targeted_attack
 using DataFrames
 
-@testset "unit" begin
+@timed_testset "unit.jl" begin
     mnist = read_datasets("MNIST")
 
     @testset "BatchRunParameters" begin

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -1,5 +1,5 @@
 using Test
 
-@testset "integration tests" begin
+@timed_testset "integration/" begin
     include("integration/sequential.jl")
 end

--- a/test/integration/sequential.jl
+++ b/test/integration/sequential.jl
@@ -1,6 +1,6 @@
 using Test
 
-@testset "sequential" begin
+@timed_testset "sequential/" begin
     include("sequential/generated_weights.jl")
     if Base.find_package("Gurobi") != nothing
         # Skip these tests if Gurobi is not installed.

--- a/test/integration/sequential/generated_weights.jl
+++ b/test/integration/sequential/generated_weights.jl
@@ -1,6 +1,6 @@
 using Test
 
-@testset "generated_weights" begin
+@timed_testset "generated_weights/" begin
     include("generated_weights/mfc+mfc+softmax.jl")
     include("generated_weights/conv+fc+softmax.jl")
 end

--- a/test/integration/sequential/generated_weights/conv+fc+softmax.jl
+++ b/test/integration/sequential/generated_weights/conv+fc+softmax.jl
@@ -6,8 +6,8 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
 @timed_testset "conv+fc+softmax.jl" begin
     ### Parameters for neural net
     batch = 1
-    c1_in_height = 8
-    c1_in_width = 8
+    c1_in_height = 6
+    c1_in_width = 6
     p1_stride_height = 2
     p1_stride_width = 2
     p1_strides = (1, p1_stride_height, p1_stride_width, 1)
@@ -18,7 +18,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
     c1_filter_width = 2
     c1_out_channels = 2
 
-    l1_height = 5
+    l1_height = 4
     l1_width = p1_height*p1_width*c1_out_channels
 
     l2_height = 3
@@ -56,7 +56,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
         pp_blur = BlurringPerturbationFamily((5, 5))
         # TODO (vtjeng): Add example where blurring perturbation generates non-NaN results
         test_cases = [
-            ((2, pp_blur, 1, 0), NaN),
+            ((2, pp_blur, 1, 0), 6.959316),
             ((3, pp_blur, 1, 0), NaN),
         ]
 
@@ -68,7 +68,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
         @timed_testset "Minimizing l1 norm" begin
             test_cases = [
                 ((1, pp_unrestricted, 1, 0), 0),
-                ((2, pp_unrestricted, 1, 0), 9.2825418),
+                ((2, pp_unrestricted, 1, 0), 0.9187638),
             ]
 
             TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
@@ -77,8 +77,8 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
         @timed_testset "Minimizing lInf norm" begin
             test_cases = [
                 ((1, pp_unrestricted, Inf, 0), 0),
-                ((2, pp_unrestricted, Inf, 0), 0.4347241),
-                ((3, pp_unrestricted, Inf, 0), 0.5045819),
+                ((2, pp_unrestricted, Inf, 0), 0.06688736),
+                ((3, pp_unrestricted, Inf, 0), 0.4270584),
             ]
 
             TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
@@ -86,7 +86,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
 
         @timed_testset "Increasing margin increases required distance" begin
             test_cases = [
-                ((2, pp_unrestricted, 1, 0.1), 9.5642628),
+                ((2, pp_unrestricted, 1, 0.1), 0.98717927),
             ]
 
             TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
@@ -94,7 +94,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
 
         @timed_testset "With multiple target labels specified, minimum target label found" begin
             test_cases = [
-                (([2, 3], pp_unrestricted, Inf, 0), 0.4347241),
+                (([2, 3], pp_unrestricted, Inf, 0), 0.06688736),
             ]
 
             TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
@@ -103,8 +103,8 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
 
     @timed_testset "LInfNormBoundedPerturbationFamily" begin
         test_cases = [
-            ((2, LInfNormBoundedPerturbationFamily(0.43), Inf, 0), NaN),  # restricting maximum perturbation to below minimum distance causes optimization problem to be infeasible
-            ((2, LInfNormBoundedPerturbationFamily(0.435), Inf, 0), 0.4347241),  # restricting maximum perturbation to above minimum distance does not affect optimal value of problem
+            ((2, LInfNormBoundedPerturbationFamily(0.06), Inf, 0), NaN),  # restricting maximum perturbation to below minimum distance causes optimization problem to be infeasible
+            ((2, LInfNormBoundedPerturbationFamily(0.07), Inf, 0), 0.06688736),  # restricting maximum perturbation to above minimum distance does not affect optimal value of problem
         ]
 
         TestHelpers.batch_test_adversarial_example(nn, input, test_cases)

--- a/test/integration/sequential/generated_weights/conv+fc+softmax.jl
+++ b/test/integration/sequential/generated_weights/conv+fc+softmax.jl
@@ -3,7 +3,7 @@ using MIPVerify
 using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LInfNormBoundedPerturbationFamily
 @isdefined(TestHelpers) || include("../../../TestHelpers.jl")
 
-@testset "Conv + FC + Softmax" begin
+@timed_testset "conv+fc+softmax.jl" begin
     ### Parameters for neural net
     batch = 1
     c1_in_height = 8
@@ -52,7 +52,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
         "tests.integration.generated_weights.conv+fc+softmax"
     )
 
-    @testset "BlurringPerturbationFamily" begin
+    @timed_testset "BlurringPerturbationFamily" begin
         pp_blur = BlurringPerturbationFamily((5, 5))
         # TODO (vtjeng): Add example where blurring perturbation generates non-NaN results
         test_cases = [
@@ -63,9 +63,9 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
         TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
     end
 
-    @testset "UnrestrictedPerturbationFamily" begin
+    @timed_testset "UnrestrictedPerturbationFamily" begin
         pp_unrestricted = UnrestrictedPerturbationFamily()
-        @testset "Minimizing l1 norm" begin
+        @timed_testset "Minimizing l1 norm" begin
             test_cases = [
                 ((1, pp_unrestricted, 1, 0), 0),
                 ((2, pp_unrestricted, 1, 0), 9.2825418),
@@ -74,7 +74,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
             TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
         end
 
-        @testset "Minimizing lInf norm" begin
+        @timed_testset "Minimizing lInf norm" begin
             test_cases = [
                 ((1, pp_unrestricted, Inf, 0), 0),
                 ((2, pp_unrestricted, Inf, 0), 0.4347241),
@@ -84,7 +84,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
             TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
         end
 
-        @testset "Increasing margin increases required distance" begin
+        @timed_testset "Increasing margin increases required distance" begin
             test_cases = [
                 ((2, pp_unrestricted, 1, 0.1), 9.5642628),
             ]
@@ -92,7 +92,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
             TestHelpers.batch_test_adversarial_example(nn, input, test_cases)
         end
 
-        @testset "With multiple target labels specified, minimum target label found" begin
+        @timed_testset "With multiple target labels specified, minimum target label found" begin
             test_cases = [
                 (([2, 3], pp_unrestricted, Inf, 0), 0.4347241),
             ]
@@ -101,7 +101,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
         end
     end
 
-    @testset "LInfNormBoundedPerturbationFamily" begin
+    @timed_testset "LInfNormBoundedPerturbationFamily" begin
         test_cases = [
             ((2, LInfNormBoundedPerturbationFamily(0.43), Inf, 0), NaN),  # restricting maximum perturbation to below minimum distance causes optimization problem to be infeasible
             ((2, LInfNormBoundedPerturbationFamily(0.435), Inf, 0), 0.4347241),  # restricting maximum perturbation to above minimum distance does not affect optimal value of problem

--- a/test/integration/sequential/generated_weights/mfc+mfc+softmax.jl
+++ b/test/integration/sequential/generated_weights/mfc+mfc+softmax.jl
@@ -3,7 +3,7 @@ using MIPVerify
 using MIPVerify: UnrestrictedPerturbationFamily, LInfNormBoundedPerturbationFamily
 @isdefined(TestHelpers) || include("../../../TestHelpers.jl")
 
-@testset "mfc + mfc + softmax" begin
+@timed_testset "mfc+mfc+softmax.jl" begin
     input = gen_array((1, 4, 8, 1), 0, 1)
 
     l1_height = 16

--- a/test/integration/sequential/trained_weights.jl
+++ b/test/integration/sequential/trained_weights.jl
@@ -1,6 +1,6 @@
 using Test
 
-@testset "trained_weights" begin
+@timed_testset "trained_weights/" begin
     include("trained_weights/MNIST.n1.jl")
     include("trained_weights/MNIST.WK17a_linf0.1_authors.jl")
 end

--- a/test/integration/sequential/trained_weights/MNIST.WK17a_linf0.1_authors.jl
+++ b/test/integration/sequential/trained_weights/MNIST.WK17a_linf0.1_authors.jl
@@ -4,7 +4,7 @@ using MIPVerify: LInfNormBoundedPerturbationFamily
 using MIPVerify: get_example_network_params, read_datasets, get_image, get_label
 @isdefined(TestHelpers) || include("../../../TestHelpers.jl")
 
-@testset "MNIST.WK17a_linf0.1_authors" begin
+@testset "MNIST.WK17a_linf0.1_authors.jl" begin
     nn = get_example_network_params("MNIST.WK17a_linf0.1_authors")
     mnist = read_datasets("mnist")
 

--- a/test/integration/sequential/trained_weights/MNIST.n1.jl
+++ b/test/integration/sequential/trained_weights/MNIST.n1.jl
@@ -4,7 +4,7 @@ using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LIn
 using MIPVerify: get_example_network_params, read_datasets, get_image
 @isdefined(TestHelpers) || include("../../../TestHelpers.jl")
 
-@testset "MNIST.n1" begin
+@testset "MNIST.n1.jl" begin
     nn = get_example_network_params("MNIST.n1")
     mnist = read_datasets("mnist")
 

--- a/test/models.jl
+++ b/test/models.jl
@@ -1,7 +1,7 @@
 using Test
 using MIPVerify: UnrestrictedPerturbationFamily, BlurringPerturbationFamily, LInfNormBoundedPerturbationFamily
 
-@testset "models.jl" begin
+@timed_testset "models.jl" begin
     @testset "UnrestrictedPerturbationFamily" begin
         @testset "Base.show" begin
             p = UnrestrictedPerturbationFamily()

--- a/test/net_components.jl
+++ b/test/net_components.jl
@@ -1,6 +1,6 @@
 using Test
 
-@testset "net_components/" begin
+@timed_testset "net_components/" begin
     include("net_components/core_ops.jl")
     include("net_components/layers.jl")
     include("net_components/nets.jl")

--- a/test/net_components/core_ops.jl
+++ b/test/net_components/core_ops.jl
@@ -10,7 +10,7 @@ function count_binary_variables(m::Model)
     count(x -> x == :Bin, m.colCat)
 end
 
-@testset "core_ops.jl" begin
+@timed_testset "core_ops.jl" begin
     @testset "is_constant" begin
         @testset "JuMP.AffExpr" begin
             m = TestHelpers.get_new_model()

--- a/test/net_components/layers.jl
+++ b/test/net_components/layers.jl
@@ -1,6 +1,6 @@
 using Test
 
-@testset "layers/" begin
+@timed_testset "layers/" begin
     include("layers/conv2d.jl")
     include("layers/flatten.jl")
     include("layers/linear.jl")

--- a/test/net_components/nets.jl
+++ b/test/net_components/nets.jl
@@ -1,5 +1,5 @@
 using Test
 
-@testset "nets/" begin
+@timed_testset "nets/" begin
     include("nets/sequential.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,10 +3,23 @@ using MIPVerify: setloglevel!
 using MIPVerify: remove_cached_models
 using MIPVerify: get_max_index, get_norm
 using JuMP
+using TimerOutputs
 
 @isdefined(TestHelpers) || include("TestHelpers.jl")
 
+macro timed_testset(name::String, block)
+    # copied from https://github.com/KristofferC/Tensors.jl/blob/master/test/runtests.jl#L8
+    return quote
+        @timeit "$($(esc(name)))" begin
+            @testset "$($(esc(name)))" begin
+                $(esc(block))
+            end
+        end
+    end
+end
+
 @testset "MIPVerify" begin
+    reset_timer!()
     setloglevel!("info")
     remove_cached_models()
 
@@ -62,5 +75,10 @@ using JuMP
             end
         end
     end
+
+    println()
+    print_timer()
+    println()
+    println()
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,6 +1,6 @@
 using Test
 
-@testset "utils" begin
+@timed_testset "utils/" begin
     include("utils/import_datasets.jl")
     include("utils/import_example_nets.jl")
 end

--- a/test/utils/import_datasets.jl
+++ b/test/utils/import_datasets.jl
@@ -2,7 +2,7 @@ using Test
 using Statistics
 using MIPVerify
 
-@testset "import_datasets.jl" begin
+@timed_testset "import_datasets.jl" begin
     @testset "NamedTrainTestDataset" begin
         @testset "Base.show" begin
             io = IOBuffer()

--- a/test/utils/import_example_nets.jl
+++ b/test/utils/import_example_nets.jl
@@ -1,19 +1,19 @@
 using Test
 using MIPVerify: get_example_network_params, read_datasets, frac_correct
 
-@testset "import_example_nets.jl" begin
-    @testset "get_example_network_params" begin
-        @testset "MNIST.n1" begin
+@timed_testset "import_example_nets.jl" begin
+    @timed_testset "get_example_network_params" begin
+        @timed_testset "MNIST.n1" begin
             nn = get_example_network_params("MNIST.n1")
             mnist = read_datasets("mnist")
             @test frac_correct(nn, mnist.test, 10000) == 0.9695
         end
-        @testset "MNIST.WK17a_linf0.1_authors" begin
+        @timed_testset "MNIST.WK17a_linf0.1_authors" begin
             nn = get_example_network_params("MNIST.WK17a_linf0.1_authors")
             mnist = read_datasets("mnist")
             @test frac_correct(nn, mnist.test, 10000) == 0.9811
         end
-        @testset "MNIST.RSL18a_linf0.1_authors" begin
+        @timed_testset "MNIST.RSL18a_linf0.1_authors" begin
             nn = get_example_network_params("MNIST.RSL18a_linf0.1_authors")
             mnist = read_datasets("mnist")
             @test frac_correct(nn, mnist.test, 10000) == 0.9582


### PR DESCRIPTION
  + Reduce amount of time tests take to run by simplifying the conv+fc+softmax.jl test (from generated `8x8` input to generated `6x6` input).
  + Add consistency to test naming: files corresponding to `folders/` including other files, `leaf_files.jl`.
  + Time tests using `TimerOutputs.jl`