### PR TITLE
Fix sum usage in skip_unit.

### DIFF
--- a/src/net_components/layers/skip_unit.jl
+++ b/src/net_components/layers/skip_unit.jl
@@ -24,7 +24,7 @@ function apply(p::SkipBlock, xs::Array)
     num_layers = length(p.layers)
     inputs = xs[end-num_layers+1:end]
     outputs = map((f, x) -> f(x), p.layers, inputs)
-    return outputs |> sum
+    return reduce((x1, x2) -> x1.+x2, outputs)
 end
 
 (p::SkipBlock)(xs::Array) = apply(p, xs)


### PR DESCRIPTION
In moving from Julia 0.6 to Julia 1.0, addition of vectors to scalars is no longer supported directly with `sum`:

```
julia> x=[1, 2, 3]; y=1; z=2; a=[x, y, z]; sum(a)
ERROR: MethodError: no method matching +(::Array{Int64, 1}, ::Int64)
...
```

This PR provides a quick fix that applies [broadcast addition](https://docs.julialang.org/en/latest/manual/arrays/#Broadcasting-1) via reduce.

## Testing
I've tested this manually using a ResNet, verifying that we can both forward propagate through the network and set up the relevant optimization problem.

We should add a test that utilizes this `SkipUnit` to prevent future failures.