### PR TITLE
Decrease TagBot action frequency to once per day.

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,7 +1,9 @@
 name: TagBot
+
 on:
   schedule:
-    - cron: 0 * * * *
+    - cron: 0 0 * * *
+
 jobs:
   TagBot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Per a conversation with on julialang.slack.com, we can reduce the frequency of `TagBot` to anything less than three days.

> @vtjeng: By default (https://github.com/JuliaRegistries/TagBot#setup), TagBot runs every hour on my repo. Is this necessary for releases to get tagged immediately, or is it fine if I reduce the frequency with which TagBot runs --- perhaps once every six hours or so? (I am suspecting that this is behind the increased clone traffic to me repository --- I'm having about 24 cloners and 48 clones on my repo after having installed the workflow, but this of course could be someone else). [...] I would be interested if you could point me to something to help me understand how TagBot allows my releases to appear within seconds of the registry PR being merged, too --- that's always been a bit magical
> 
> @christopher-dG: You can reduce the frequency to anything less than three days! [...] Three days: It's hard coded to only check for releases of that age or younger. [...] Okay so TagBot used to be a GitHub App that was installed on the Julia package registry by me and on the package repos by their owners. It reacted to webhook events: the PRs being merged. So that let it do the releases in just seconds. Now TagBot has migrated to GitHub Actions, which is a different model and only exists in your repo (i.e. doesn't get notified when the registry PR gets merged) so it has to just poll for new versions. It might seem less good but one big benefit is that you can verify that the code in the TagBot repo is what is actually running in your GitHub Action; there was no way to do this with the GitHub App and it's a concern when you're handing over write access to your repository.
