### PR TITLE
Added valid and fixed padding.

### DIFF
--- a/src/net_components/layers/conv2d.jl
+++ b/src/net_components/layers/conv2d.jl
@@ -2,6 +2,11 @@ using JuMP
 using ConditionalJuMP
 
 export Conv2d
+export Padding, same, valid
+
+@enum DynamicPadding same=1 valid=2
+FixedPadding = Union{Int64, Tuple{Int64, Int64}, Tuple{Int64, Int64, Int64, Int64}}
+Padding = Union{DynamicPadding, FixedPadding}
 
 """
 $(TYPEDEF)
@@ -18,25 +23,30 @@ $(FIELDS)
     filter::Array{T, 4}
     bias::Array{U, 1}
     stride::V
+    padding::Padding
 
-    function Conv2d{T, U, V}(filter::Array{T, 4}, bias::Array{U, 1}, stride::V) where {T<:JuMPReal, U<:JuMPReal, V<:Int64}
+    function Conv2d{T, U, V}(filter::Array{T, 4}, bias::Array{U, 1}, stride::V, padding::Padding) where {T<:JuMPReal, U<:JuMPReal, V<:Int64}
         (filter_height, filter_width, filter_in_channels, filter_out_channels) = size(filter)
         bias_out_channels = length(bias)
         @assert(
             filter_out_channels == bias_out_channels,
             "For this convolution layer, number of output channels in filter, $filter_out_channels, does not match number of output channels in bias, $bias_out_channels."
         )
-        return new(filter, bias, stride)
+        return new(filter, bias, stride, padding)
     end
 
 end
 
+function Conv2d(filter::Array{T, 4}, bias::Array{U, 1}, stride::V, padding::Padding) where {T<:JuMPReal, U<:JuMPReal, V<:Int64}
+    Conv2d{T, U, V}(filter, bias, stride, padding)
+end
+
 function Conv2d(filter::Array{T, 4}, bias::Array{U, 1}, stride::V) where {T<:JuMPReal, U<:JuMPReal, V<:Int64}
-    Conv2d{T, U, V}(filter, bias, stride)
+    Conv2d{T, U, V}(filter, bias, stride, same)
 end
 
 function Conv2d(filter::Array{T, 4}, bias::Array{U, 1}) where {T<:JuMPReal, U<:JuMPReal}
-    Conv2d(filter, bias, 1)
+    Conv2d(filter, bias, 1, same)
 end
 
 """
@@ -59,8 +69,9 @@ end
 function Base.show(io::IO, p::Conv2d)
     (filter_height, filter_width, filter_in_channels, filter_out_channels) = size(p.filter)
     stride = p.stride
+    padding = p.padding
     print(io,
-        "Conv2d($filter_in_channels, $filter_out_channels, kernel_size=($(filter_height), $(filter_width)), stride=($(stride), $(stride)), padding=same)"
+        "Conv2d($filter_in_channels, $filter_out_channels, kernel_size=($(filter_height), $(filter_width)), stride=($(stride), $(stride)), padding=$(padding))"
     )
 end
 
@@ -93,8 +104,15 @@ $(SIGNATURES)
 
 Computes the result of convolving `input` with the `filter` and `bias` stored in `params`.
 
-Mirrors `tf.nn.conv2d` from the `tensorflow` package, with `strides = [1, 1, 1, 1], 
-padding = 'SAME'`.
+Mirrors `tf.nn.conv2d` from the `tensorflow` package, with `strides = [1, 1, 1, 1].
+
+Supports three types of padding:
+- 'same': Padding is added so that the output has the same size as the input.
+- 'valid': No padding is added
+- Fixed:
+  - Int64:                             Interpreted as padding for both axes
+  - Tuple{Int64, Int64}:               Interpreted as (y_padding, x_padding)
+  - Tuple{Int64, Int64, Int64, Int64}: Interpreted as (top, bottom, left, right)
 
 # Throws
 * AssertionError if `input` and `filter` are not compatible.
@@ -104,34 +122,61 @@ function conv2d(
     params::Conv2d{U, V}) where {T<:JuMPReal, U<:JuMPReal, V<:JuMPReal}
 
     if T<:JuMPLinearType || U<:JuMPLinearType || V<:JuMPLinearType
-        Memento.info(MIPVerify.LOGGER, "Applying $(params) ... ")
+        info(MIPVerify.LOGGER, "Applying $(params) ... ")
     end
     filter = params.filter
     stride = params.stride
+    padding = params.padding
 
     (batch, in_height, in_width, input_in_channels) = size(input)
     (filter_height, filter_width, filter_in_channels, filter_out_channels) = size(filter)
     
     @assert(
-        input_in_channels == filter_in_channels, 
+        input_in_channels == filter_in_channels,
         "Number of channels in input, $input_in_channels, does not match number of channels, $filter_in_channels, that filters operate on."
     )
-    
-    out_height = round(Int, in_height/stride, RoundUp)
-    out_width = round(Int, in_width/stride, RoundUp)
-    output_size = (batch, out_height, out_width, filter_out_channels)
 
     # Considered using offset arrays here, but could not get it working.
 
-    # Calculating appropriate offsets so that center of kernel is matched with
-    # cell at which correlation is being calculated. Note that tensorflow
-    # chooses a specific convention for a dimension with even size which we
-    # replicate here.
-    pad_along_height = max((out_height - 1)*stride + filter_height - in_height, 0)
-    pad_along_width = max((out_width - 1)*stride + filter_width - in_width, 0)
-    filter_height_offset = round(Int, pad_along_height/2, RoundDown)
-    filter_width_offset = round(Int, pad_along_width/2, RoundDown)
-    
+    if padding == same
+        out_height = round(Int, in_height/stride, RoundUp)
+        out_width = round(Int, in_width/stride, RoundUp)
+        output_size = (batch, out_height, out_width, filter_out_channels)
+        pad_along_height = max((out_height - 1)*stride + filter_height - in_height, 0)
+        pad_along_width = max((out_width - 1)*stride + filter_width - in_width, 0)
+        filter_height_offset = round(Int, pad_along_height/2, RoundDown)
+        filter_width_offset = round(Int, pad_along_width/2, RoundDown)
+    elseif padding == valid
+        out_height = round(Int, (in_height + 1 - filter_height) / stride, RoundUp)
+        out_width = round(Int, (in_width + 1 - filter_width) / stride, RoundUp)
+        output_size = (batch, out_height, out_width, filter_out_channels)
+        filter_height_offset = 0
+        filter_width_offset = 0
+    elseif padding isa FixedPadding
+        if padding isa Int64
+            top_padding = padding
+            bottom_padding = padding
+            left_padding = padding
+            right_padding = padding
+        elseif padding isa Tuple{Int64, Int64}
+            (y_padding, x_padding) = padding
+            top_padding = y_padding
+            bottom_padding = y_padding
+            left_padding = x_padding
+            right_padding = x_padding
+        else
+            (top_padding, bottom_padding, left_padding, right_padding) = padding
+        end
+
+        out_height = round(Int, (in_height + top_padding + bottom_padding - filter_height) / stride, RoundDown) + 1
+        out_width = round(Int, (in_width + left_padding + right_padding - filter_width) / stride, RoundDown) + 1
+        output_size = (batch, out_height, out_width, filter_out_channels)
+        filter_height_offset = top_padding
+        filter_width_offset = left_padding
+    else
+        error("Unknown padding type $padding")
+    end
+
     W = Base.promote_op(+, V, Base.promote_op(*, T, U))
     output = Array{W}(undef, output_size)
 

--- a/src/utils/import_weights.jl
+++ b/src/utils/import_weights.jl
@@ -3,7 +3,7 @@ export get_matrix_params, get_conv_params, get_example_network_params
 """
 $(SIGNATURES)
 
-Helper function to import the parameters for a layer carrying out matrix multiplication 
+Helper function to import the parameters for a layer carrying out matrix multiplication
     (e.g. fully connected layer / softmax layer) from `param_dict` as a
     [`Linear`](@ref) object.
 
@@ -62,13 +62,15 @@ function get_conv_params(
     expected_size::NTuple{4, Int};
     matrix_name::String = "weight",
     bias_name::String = "bias",
-    expected_stride::Integer = 1
+    expected_stride::Integer = 1,
+    padding::Padding = same
     )::Conv2d
 
     params = Conv2d(
         param_dict["$layer_name/$matrix_name"],
         dropdims(param_dict["$layer_name/$bias_name"], dims=1),
-        expected_stride
+        expected_stride,
+        padding
     )
 
     check_size(params, expected_size)

--- a/test/net_components/layers/conv2d.jl
+++ b/test/net_components/layers/conv2d.jl
@@ -346,10 +346,9 @@ using MIPVerify: check_size, increment!
             bias = [0]
             stride = 1
             true_output_raw = [
-                39  45  51;
-                57  69  75;
-                81  87  99;
-                105 111 117
+                39  45  51  57;
+                69  75  81  87;
+                99  105 111 117
             ]
             true_output = reshape(transpose(true_output_raw), (1, 4, 3, 1))
             p = Conv2d(filter, bias, stride, valid)
@@ -1258,7 +1257,7 @@ using MIPVerify: check_size, increment!
             padding = (1, 2, 3, 4)
             true_output_raw = [
                0   0   0   0   0   0;
-               3   6   9  12   9   5
+               3   6   9  12   9   5;
                16  27  33  39  28  15;
                39  63  72  81  57  30;
                69  108 117 126 87  45;

--- a/test/net_components/layers/conv2d.jl
+++ b/test/net_components/layers/conv2d.jl
@@ -5,7 +5,6 @@ using MIPVerify: check_size, increment!
 @isdefined(TestHelpers) || include("../../TestHelpers.jl")
 
 @testset "conv2d.jl" begin
-
     @testset "Conv2d" begin
         @testset "Base.show" begin
             filter = ones(3, 3, 2, 5)
@@ -201,6 +200,1103 @@ using MIPVerify: check_size, increment!
 
             solve_output = MIPVerify.conv2d(getvalue(input_v), p)
             @test solve_output≈true_output
+        end
+    end
+
+    @testset "conv2d with 'valid' padding" begin
+        @testset "conv2d with 'valid' padding, odd input and filter size, stride = 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            true_output_raw = [
+                63 72 81;
+                108 117 126;
+                153 162 171
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, odd input and filter size, stride = 1, channels != 1" begin
+            input_size = (1, 5, 5, 2)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 2, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            true_output_raw = [
+                351 369 387;
+                441 459 477;
+                531 549 567
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, stride = 1, input width != input height" begin
+            input_size = (1, 5, 6, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            true_output_raw = [
+                63  72  81;
+                108 117 126;
+                153 162 171;
+                198 207 216
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 3, 4, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, stride=1, filter width != filter height" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (2, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            true_output_raw = [
+                39  45  51;
+                57  69  75;
+                81  87  99;
+                105 111 117
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 4, 3, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, odd input and filter size, stride != 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 2
+            true_output_raw = [
+                63  81;
+                153 171
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, odd input size, even filter size, stride = 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (2, 2, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            true_output_raw = [
+                16 20 24 28;
+                36 40 44 48;
+                56 60 64 68;
+                76 80 84 88
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 4, 4, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, odd input size, even filter size, stride != 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (2, 2, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 2
+            true_output_raw = [
+                16 24;
+                56 64
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, even input size, odd filter size, stride = 1" begin
+            input_size = (1, 6, 6, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            true_output_raw = [
+                72  81  90  99;
+                126 135 144 153;
+                180 189 198 207;
+                234 243 252 261
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 4, 4, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, even input size, odd filter size, stride != 1" begin
+            input_size = (1, 6, 6, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 2
+            true_output_raw = [
+                72  90;
+                180 198
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, even input and filter size, stride = 1" begin
+            input_size = (1, 6, 6, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (2, 2, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            true_output_raw = [
+                18  22  26  30  34;
+                42  46  50  54  58;
+                66  70  74  78  82;
+                90  94  98  102 106;
+                114 118 122 126 130
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 'valid' padding, even input and filter size, stride != 1" begin
+            input_size = (1, 6, 6, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (2, 2, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 3
+            true_output_raw = [
+                18  30;
+                90 102
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            p = Conv2d(filter, bias, stride, valid)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, valid)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, valid)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+    end
+
+    @testset "conv2d wit fixed padding" begin
+        @testset "conv2d with (0, 0) padding, stride = 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            padding = (0, 0)
+            true_output_raw = [
+                63  72  81;
+                108 117 126;
+                153 162 171
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (0, 0) padding, stride != 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 2
+            padding = (0, 0)
+            true_output_raw = [
+                63  81;
+                153 171;
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 2, 2, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 1) padding, stride = 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            padding = (1, 1)
+            true_output_raw = [
+                16  27  33  39  28;
+                39  63  72  81  57;
+                69  108 117 126 87;
+                99  153 162 171 117;
+                76  117 123 129 88
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 1) padding, stride != 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 2
+            padding = (1, 1)
+            true_output_raw = [
+                16 33  28;
+                69 117 87;
+                76 123 88
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with 1 padding, stride = 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            padding = 1
+            true_output_raw = [
+                16  27  33  39  28;
+                39  63  72  81  57;
+                69  108 117 126 87;
+                99  153 162 171 117;
+                76  117 123 129 88
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 1) padding, input width != input_height, stride = 1" begin
+            input_size = (1, 6, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            padding = (1, 1)
+            true_output_raw = [
+                18  30  36  42  48;
+                34  45  72  81  90;
+                99  69  81  126 135;
+                144 153 105 117 180;
+                189 198 207 141 90;
+                138 144 150 156 106
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 6, 5, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 1) padding, input width != input_height, stride != 1" begin
+            input_size = (1, 6, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 2
+            padding = (1, 1)
+            true_output_raw = [
+                18  36  48;
+                81  135 153;
+                90  144 156
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 2) padding, stride = 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            padding = (1, 2)
+            true_output_raw = [
+                3   6   9   12  9;
+                16  27  33  39  28;
+                39  63  72  81  57;
+                69  108 117 126 87;
+                99  153 162 171 117;
+                76  117 123 129 88;
+                43  66  69  72  49
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 5, 7, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 2) padding, stride != 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 2
+            padding = (1, 2)
+            true_output_raw = [
+               3   9   9;
+               39  72  57;
+               99  162 117;
+               43  69  49
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 3, 4, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 1) padding, channels != 1, stride = 1" begin
+            input_size = (1, 5, 5, 2)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 2, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            padding = (1, 1)
+            true_output_raw = [
+                132 204 216 228 156;
+                228 351 369 387 264;
+                288 441 459 477 324;
+                348 531 549 567 384;
+                252 384 396 408 276
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 1) padding, channels != 1, stride != 1" begin
+            input_size = (1, 5, 5, 2)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 2, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 2
+            padding = (1, 1)
+            true_output_raw = [
+                132 216 156;
+                288 459 324;
+                252 396 276
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 3, 3, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 1, 1, 1) padding, stride = 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            padding = (1, 1, 1, 1)
+            true_output_raw = [
+                16  27  33  39  28;
+                39  63  72  81  57;
+                69  108 117 126 87;
+                99  153 162 171 117;
+                76  117 123 129 88
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 5, 5, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
+        end
+
+        @testset "conv2d with (1, 2, 3, 4) padding, stride = 1" begin
+            input_size = (1, 5, 5, 1)
+            input = reshape([1:prod(input_size);], input_size)
+            filter_size = (3, 3, 1, 1)
+            filter = ones(filter_size...)
+            bias_size = (1, )
+            bias = [0]
+            stride = 1
+            padding = (1, 2, 3, 4)
+            true_output_raw = [
+               0   0   0   0   0   0;
+               3   6   9  12   9   5
+               16  27  33  39  28  15;
+               39  63  72  81  57  30;
+               69  108 117 126 87  45;
+               99  153 162 171 117 60;
+               76  117 123 129 88  45;
+               43  66  69  72  49  25;
+               0   0   0   0   0   0;
+               0   0   0   0   0   0
+            ]
+            true_output = reshape(transpose(true_output_raw), (1, 6, 10, 1))
+            p = Conv2d(filter, bias, stride, padding)
+            @testset "Numerical Input, Numerical Layer Parameters" begin
+                evaluated_output = MIPVerify.conv2d(input, p)
+                @test evaluated_output == true_output
+            end
+            @testset "Numerical Input, Variable Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                filter_v = map(_ -> @variable(m), CartesianIndices(filter_size))
+                bias_v = map(_ -> @variable(m), CartesianIndices(bias_size))
+                p_v = Conv2d(filter_v, bias_v, stride, padding)
+                output_v = MIPVerify.conv2d(input, p_v)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                p_solve = MIPVerify.Conv2d(getvalue(filter_v), getvalue(bias_v), stride, padding)
+                solve_output = MIPVerify.conv2d(input, p_solve)
+                @test solve_output≈true_output
+            end
+            @testset "Variable Input, Numerical Layer Parameters" begin
+                m = TestHelpers.get_new_model()
+                input_v = map(_ -> @variable(m), CartesianIndices(input_size))
+                output_v = MIPVerify.conv2d(input_v, p)
+                @constraint(m, output_v .== true_output)
+                solve(m)
+
+                solve_output = MIPVerify.conv2d(getvalue(input_v), p)
+                @test solve_output≈true_output
+            end
         end
     end
 end


### PR DESCRIPTION
Using #16 as a starting point, I added support for both valid and fixed padding.
Fixed padding can be passed as `Int64` (same padding for all edges), a tuple of size 2 (y_padding, x_padding) or a tuple of size 4 (top, bottom, left, right).
The implementation follows Tensorflow's conventions, but just to be sure I checked that it matches PyTorch's implementation too.
This is my first time working on MIPVerify, so I might have been a bit overzealous with the unit tests. If that's the case, I'll remove some of them.

Edit: passing -> padding