### PR TITLE
Deprecate caching of models.

### DIFF
--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -14,7 +14,6 @@ We suggest getting started with the tutorials.
   + Have more precise control over the activations in the output layer
   + Restrict the family of perturbations (for example to the blurring perturbations discussed in our paper)
   + Select whether you want to minimize the $L_1$, $L_2$ or $L_\infty$ norm of the perturbation.
-  + Determine whether you are rebuilding the model expressing the constraints of the neural network from scratch, or loading the model from cache.
   + Modify the amount of time dedicated to building the model (by selecting the `tightening_algorithm`, and/or passing in a custom `tightening_solver`).
 
 For Gurobi, we show how to specify solver settings to:

--- a/src/MIPVerify.jl
+++ b/src/MIPVerify.jl
@@ -69,10 +69,6 @@ We guarantee that `y[j] - y[i] ≥ 0` for some `j ∈ target_selection` and for 
 + `tightening_solver`: Solver used to determine upper and lower bounds for input to nonlinear units.
     Defaults to the same type of solver as the `main_solver`, with a time limit of 20s per solver
     and output suppressed. Used only if the `tightening_algorithm` is `lp` or `mip`.
-+ `rebuild::Bool`: Defaults to `false`. If `true`, rebuilds model by determining upper and lower
-    bounds on input to each non-linear unit even if a cached model exists.
-+ `cache_model`: Defaults to `true`. If `true`, saves model generated. If `false`, does not save model
-    generated, but any existing cached model is retained.
 + `solve_if_predicted_in_targeted`: Defaults to `true`. The prediction that `nn` makes for the unperturbed
     `input` can be determined efficiently. If the predicted index is one of the indexes in `target_selection`,
     we can skip the relatively costly process of building the model for the MIP problem since we already have an
@@ -92,8 +88,6 @@ function find_adversarial_example(
     tightening_solver::MathProgBase.SolverInterface.AbstractMathProgSolver = get_default_tightening_solver(
         main_solver,
     ),
-    rebuild::Bool = false,
-    cache_model::Bool = true,
     solve_if_predicted_in_targeted = true,
 )::Dict
 
@@ -128,8 +122,6 @@ function find_adversarial_example(
                     pp,
                     tightening_solver,
                     tightening_algorithm,
-                    rebuild,
-                    cache_model,
                 ),
             )
             m = d[:Model]

--- a/src/MIPVerify.jl
+++ b/src/MIPVerify.jl
@@ -114,16 +114,7 @@ function find_adversarial_example(
 
         # Only call solver if predicted index is not found among target indexes.
         if !(d[:PredictedIndex] in d[:TargetIndexes]) || solve_if_predicted_in_targeted
-            merge!(
-                d,
-                get_model(
-                    nn,
-                    input,
-                    pp,
-                    tightening_solver,
-                    tightening_algorithm,
-                ),
-            )
+            merge!(d, get_model(nn, input, pp, tightening_solver, tightening_algorithm))
             m = d[:Model]
 
             if adversarial_example_objective == closest

--- a/src/batch_processing_helpers.jl
+++ b/src/batch_processing_helpers.jl
@@ -240,7 +240,7 @@ particular index.
 
 # Named Arguments:
 + `save_path`: Directory where results will be saved. Defaults to current directory.
-+ `pp, norm_order, rebuild, tightening_algorithm, tightening_solver, cache_model,
++ `pp, norm_order, tightening_algorithm, tightening_solver,
   solve_if_predicted_in_targeted` are passed
   through to [`find_adversarial_example`](@ref) and have the same default values;
   see documentation for that function for more details.
@@ -257,12 +257,10 @@ function batch_find_untargeted_attack(
     solve_rerun_option::MIPVerify.SolveRerunOption = MIPVerify.never,
     pp::MIPVerify.PerturbationFamily = MIPVerify.UnrestrictedPerturbationFamily(),
     norm_order::Real = 1,
-    rebuild = false,
     tightening_algorithm::MIPVerify.TighteningAlgorithm = DEFAULT_TIGHTENING_ALGORITHM,
     tightening_solver::MathProgBase.SolverInterface.AbstractMathProgSolver = MIPVerify.get_default_tightening_solver(
         main_solver,
     ),
-    cache_model = true,
     solve_if_predicted_in_targeted = true,
     adversarial_example_objective::AdversarialExampleObjective = closest,
 )::Nothing
@@ -286,10 +284,8 @@ function batch_find_untargeted_attack(
                 invert_target_selection = true,
                 pp = pp,
                 norm_order = norm_order,
-                rebuild = rebuild,
                 tightening_algorithm = tightening_algorithm,
                 tightening_solver = tightening_solver,
-                cache_model = cache_model,
                 solve_if_predicted_in_targeted = solve_if_predicted_in_targeted,
                 adversarial_example_objective = adversarial_example_objective,
             )
@@ -371,12 +367,10 @@ function batch_find_targeted_attack(
     target_labels::AbstractArray{<:Integer} = [],
     pp::MIPVerify.PerturbationFamily = MIPVerify.UnrestrictedPerturbationFamily(),
     norm_order::Real = 1,
-    rebuild = false,
     tightening_algorithm::MIPVerify.TighteningAlgorithm = DEFAULT_TIGHTENING_ALGORITHM,
     tightening_solver::MathProgBase.SolverInterface.AbstractMathProgSolver = MIPVerify.get_default_tightening_solver(
         main_solver,
     ),
-    cache_model = true,
     solve_if_predicted_in_targeted = true,
 )::Nothing
     results_dir = "run_results"
@@ -414,10 +408,8 @@ function batch_find_targeted_attack(
                     invert_target_selection = false,
                     pp = pp,
                     norm_order = norm_order,
-                    rebuild = rebuild,
                     tightening_algorithm = tightening_algorithm,
                     tightening_solver = tightening_solver,
-                    cache_model = cache_model,
                     solve_if_predicted_in_targeted = solve_if_predicted_in_targeted,
                 )
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,4 +1,3 @@
-using AutoHashEquals
 using MathProgBase
 using Serialization
 
@@ -9,7 +8,6 @@ abstract type PerturbationFamily end
 
 struct UnrestrictedPerturbationFamily <: PerturbationFamily end
 Base.show(io::IO, pp::UnrestrictedPerturbationFamily) = print(io, "unrestricted")
-Base.hash(a::UnrestrictedPerturbationFamily, h::UInt) = hash(:UnrestrictedPerturbationFamily, h)
 
 abstract type RestrictedPerturbationFamily <: PerturbationFamily end
 
@@ -18,13 +16,13 @@ For blurring perturbations, we currently allow colors to "bleed" across color ch
 that is, the value of the output of channel 1 can depend on the input to all channels.
 (This is something that is worth reconsidering if we are working on color input).
 """
-@auto_hash_equals struct BlurringPerturbationFamily <: RestrictedPerturbationFamily
+struct BlurringPerturbationFamily <: RestrictedPerturbationFamily
     blur_kernel_size::NTuple{2}
 end
 Base.show(io::IO, pp::BlurringPerturbationFamily) =
     print(io, filter(x -> !isspace(x), "blur-$(pp.blur_kernel_size)"))
 
-@auto_hash_equals struct LInfNormBoundedPerturbationFamily <: RestrictedPerturbationFamily
+struct LInfNormBoundedPerturbationFamily <: RestrictedPerturbationFamily
     norm_bound::Real
 
     function LInfNormBoundedPerturbationFamily(norm_bound::Real)

--- a/src/models.jl
+++ b/src/models.jl
@@ -61,11 +61,8 @@ function build_reusable_model_uncached(
 
     input_range = CartesianIndices(size(input))
 
-    # v_input will be constrained to `input` in the caller
-    v_input = map(_ -> @variable(m), input_range)
     # v_x0 is the input with the perturbation added
     v_x0 = map(_ -> @variable(m, lowerbound = 0, upperbound = 1), input_range)
-    @constraint(m, v_x0 .== v_input + v_e)
 
     v_output = v_x0 |> nn
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -46,13 +46,7 @@ function get_model(
         MIPVerify.LOGGER,
         "Determining upper and lower bounds for the input to each non-linear unit.",
     )
-    d = build_reusable_model_uncached(
-        nn,
-        input,
-        pp,
-        tightening_solver,
-        tightening_algorithm,
-    )
+    d = build_reusable_model_uncached(nn, input, pp, tightening_solver, tightening_algorithm)
     return d
 end
 

--- a/src/net_components/layers/conv2d.jl
+++ b/src/net_components/layers/conv2d.jl
@@ -23,7 +23,7 @@ Represents 2-D convolution operation.
 ## Fields:
 $(FIELDS)
 """
-@auto_hash_equals struct Conv2d{T<:JuMPReal,U<:JuMPReal,V<:Int64} <: Layer
+struct Conv2d{T<:JuMPReal,U<:JuMPReal,V<:Int64} <: Layer
     filter::Array{T,4}
     bias::Array{U,1}
     stride::V

--- a/src/net_components/layers/flatten.jl
+++ b/src/net_components/layers/flatten.jl
@@ -11,7 +11,7 @@ Represents a flattening operation.
 ## Fields:
 $(FIELDS)
 """
-@auto_hash_equals struct Flatten{T<:Integer} <: Layer
+struct Flatten{T<:Integer} <: Layer
     n_dim::Integer
     perm::AbstractArray{T}
 

--- a/src/net_components/layers/linear.jl
+++ b/src/net_components/layers/linear.jl
@@ -13,7 +13,7 @@ Represents matrix multiplication.
 ## Fields:
 $(FIELDS)
 """
-@auto_hash_equals struct Linear{T<:Real,U<:Real} <: Layer
+struct Linear{T<:Real,U<:Real} <: Layer
     matrix::Array{T,2}
     bias::Array{U,1}
 

--- a/src/net_components/layers/masked_relu.jl
+++ b/src/net_components/layers/masked_relu.jl
@@ -12,7 +12,7 @@ each output.
 ## Fields:
 $(FIELDS)
 """
-@auto_hash_equals struct MaskedReLU{T<:Real} <: Layer
+struct MaskedReLU{T<:Real} <: Layer
     mask::Array{T}
     tightening_algorithm::Union{TighteningAlgorithm,Nothing}
 end

--- a/src/net_components/layers/normalize.jl
+++ b/src/net_components/layers/normalize.jl
@@ -5,7 +5,7 @@ $(TYPEDEF)
 
 Represents a Normalization operation.
 """
-@auto_hash_equals struct Normalize <: Layer
+struct Normalize <: Layer
     mean::Array{Real,1}
     std::Array{Real,1}
 end

--- a/src/net_components/layers/pool.jl
+++ b/src/net_components/layers/pool.jl
@@ -24,8 +24,6 @@ function Base.show(io::IO, p::Pool)
     )
 end
 
-Base.hash(a::Pool, h::UInt) = hash(a.strides, hash(string(a.pooling_function), hash(:Pool, h)))
-
 """
 $(SIGNATURES)
 

--- a/src/net_components/layers/relu.jl
+++ b/src/net_components/layers/relu.jl
@@ -14,8 +14,6 @@ end
 
 ReLU() = ReLU(nothing)
 
-Base.hash(a::ReLU, h::UInt) = hash(:ReLU, h)
-
 function Base.show(io::IO, p::ReLU)
     print(io, "ReLU()")
 end

--- a/src/net_components/layers/skip_unit.jl
+++ b/src/net_components/layers/skip_unit.jl
@@ -8,7 +8,7 @@ TODO (vtjeng)
 ## Fields:
 $(FIELDS)
 """
-@auto_hash_equals struct SkipBlock <: Layer
+struct SkipBlock <: Layer
     layers::Array{<:Layer}
 end
 

--- a/src/net_components/layers/zero.jl
+++ b/src/net_components/layers/zero.jl
@@ -7,8 +7,6 @@ Always outputs exactly zero.
 """
 struct Zero <: Layer end
 
-Base.hash(a::Zero, h::UInt) = hash(:Zero, h)
-
 function Base.show(io::IO, p::Zero)
     print(io, "Zero()")
 end

--- a/src/net_components/nets/sequential.jl
+++ b/src/net_components/nets/sequential.jl
@@ -9,7 +9,7 @@ to output.
 ## Fields:
 $(FIELDS)
 """
-@auto_hash_equals struct Sequential <: NeuralNet
+struct Sequential <: NeuralNet
     layers::Array{Layer,1}
     UUID::String
 end

--- a/src/net_components/nets/skip_sequential.jl
+++ b/src/net_components/nets/skip_sequential.jl
@@ -9,7 +9,7 @@ to output.
 ## Fields:
 $(FIELDS)
 """
-@auto_hash_equals struct SkipSequential <: NeuralNet
+struct SkipSequential <: NeuralNet
     layers::Array{Layer,1}
     UUID::String
 end

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -61,7 +61,6 @@ function test_find_adversarial_example(
         get_main_solver(),
         pp = pp,
         norm_order = norm_order,
-        rebuild = false,
         tightening_solver = get_tightening_solver(),
         tightening_algorithm = TEST_DEFAULT_TIGHTENING_ALGORITHM,
         invert_target_selection = invert_target_selection,

--- a/test/batch_processing_helpers/integration.jl
+++ b/test/batch_processing_helpers/integration.jl
@@ -16,10 +16,8 @@ using MIPVerify: LInfNormBoundedPerturbationFamily
                 solve_rerun_option = MIPVerify.never,
                 pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.1),
                 norm_order = Inf,
-                rebuild = true,
                 tightening_algorithm = lp,
                 tightening_solver = TestHelpers.get_tightening_solver(),
-                cache_model = false,
                 solve_if_predicted_in_targeted = false,
                 save_path = dir,
             )
@@ -34,9 +32,7 @@ using MIPVerify: LInfNormBoundedPerturbationFamily
                 solve_rerun_option = MIPVerify.never,
                 pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.1),
                 norm_order = Inf,
-                rebuild = true,
                 tightening_algorithm = interval_arithmetic,
-                cache_model = false,
                 solve_if_predicted_in_targeted = false,
                 save_path = dir,
             )
@@ -55,7 +51,6 @@ using MIPVerify: LInfNormBoundedPerturbationFamily
                 norm_order = Inf,
                 tightening_algorithm = interval_arithmetic,
                 tightening_solver = TestHelpers.get_tightening_solver(),
-                cache_model = false,
                 solve_if_predicted_in_targeted = false,
                 target_labels = [1, 8],
                 save_path = dir,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Test
 using MIPVerify: setloglevel!
-using MIPVerify: remove_cached_models
 using MIPVerify: get_max_index, get_norm
 using JuMP
 using TimerOutputs
@@ -21,7 +20,6 @@ end
 @testset "MIPVerify" begin
     reset_timer!()
     setloglevel!("info")
-    remove_cached_models()
 
     include("integration.jl")
     include("net_components.jl")


### PR DESCRIPTION
We no longer really use this, since there is a limited use-case for supporting models that take a very long time to build. (We  work on speeding up the models instead).