### PR TITLE
Update minimum supported Julia version to 1.3.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
         version:
           # we are excluding nightly builds because they can fail, and we want this to be
           # a required check
-          - "1.0" # minimum Julia version that this package supports
+          - "1.3" # minimum Julia version that this package supports
           - "1" # automatically expands to latest stable 1.x release of Julia
         os:
           - ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
           - x64
         include:
           - os: ubuntu-latest
-            version: "1.0"
+            version: "1.3" # minimum Julia version that this package supports
             arch: x86
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,6 @@ jobs:
           - windows-latest
         arch:
           - x64
-        include:
-          - os: ubuntu-latest
-            version: "1.3" # minimum Julia version that this package supports
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ MathOptInterface = "0.9, 0.10, 1.0"
 Memento = "0.12, 0.13, 1.0"
 ProgressMeter = "1"
 TimerOutputs = "0.5"
-julia = "1"
+julia = "1.3"
 
 [extras]
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"


### PR DESCRIPTION
Removing support for x86 due to the following error in the `HDF5` package. (Observed in 1.3, 1.7, and presumably all versions in between).

```
ERROR: LoadError: UndefVarError: libhdf5 not defined
Stacktrace:
  [1] top-level scope
    @ ~/.julia/packages/HDF5/wWr4z/src/api/types.jl:157
  [2] include(mod::Module, _path::String)
    @ Base ./Base.jl:418
  [3] include(x::String)
    @ HDF5.API ~/.julia/packages/HDF5/wWr4z/src/api/api.jl:1
  [4] top-level scope
    @ ~/.julia/packages/HDF5/wWr4z/src/api/api.jl:14
  [5] include(mod::Module, _path::String)
    @ Base ./Base.jl:418
  [6] include(x::String)
    @ HDF5 ~/.julia/packages/HDF5/wWr4z/src/HDF5.jl:1
  [7] top-level scope
    @ ~/.julia/packages/HDF5/wWr4z/src/HDF5.jl:43
  [8] include
    @ ./Base.jl:418 [inlined]
  [9] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::String)
    @ Base ./loading.jl:1318
 [10] top-level scope
    @ none:1
 [11] eval
    @ ./boot.jl:373 [inlined]
 [12] eval(x::Expr)
    @ Base.MainInclude ./client.jl:453
 [13] top-level scope
    @ none:1
in expression starting at /home/runner/.julia/packages/HDF5/wWr4z/src/api/types.jl:157
in expression starting at /home/runner/.julia/packages/HDF5/wWr4z/src/api/api.jl:1
in expression starting at /home/runner/.julia/packages/HDF5/wWr4z/src/HDF5.jl:1
ERROR: LoadError: Failed to precompile HDF5 [f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f] to /home/runner/.julia/compiled/v1.7/HDF5/jl_7IZ6kW.
```