### PR TITLE
Re-enable documentation hosting.

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MIPVerify = "e5e5f8be-2a6a-5994-adbb-5afbd0e30425"
 
 [compat]
-Documenter = "~0.23"
+Documenter = "0.27"

--- a/docs/src/net_components/layers.md
+++ b/docs/src/net_components/layers.md
@@ -1,4 +1,5 @@
 # Layers
+
 Each layer in the neural net corresponds to a `struct` that simultaneously specifies: 1) the operation being carried out in the layer (recorded in the type of the `struct`) and 2) the parameters for the operation (recorded in the values of the fields of the `struct`).
 
 When we pass an input array of real numbers to a layer `struct`, we get an output array of real numbers that is the result of the layer operating on the input.
@@ -7,12 +8,14 @@ Conversely, when we pass an input array of `JuMP` variables, we get an output ar
 by the layer) imposed between the input and output.
 
 ## Index
+
 ```@index
 Pages   = ["layers.md"]
 Order   = [:function, :type]
 ```
 
 ## Public Interface
+
 ```@autodocs
 Modules = [MIPVerify]
 Order   = [:function, :type]
@@ -21,13 +24,17 @@ Pages   = [
     "net_components/layers/flatten.jl",
     "net_components/layers/linear.jl",
     "net_components/layers/masked_relu.jl",
+    "net_components/layers/normalize.jl",
     "net_components/layers/pool.jl",
-    "net_components/layers/relu.jl"
+    "net_components/layers/relu.jl",
+    "net_components/layers/skip_unit.jl",
+    "net_components/layers/zero.jl",
     ]
 Private = false
 ```
 
 ## Internal
+
 ```@autodocs
 Modules = [MIPVerify]
 Order   = [:function, :type]
@@ -36,8 +43,11 @@ Pages   = [
     "net_components/layers/flatten.jl",
     "net_components/layers/linear.jl",
     "net_components/layers/masked_relu.jl",
+    "net_components/layers/normalize.jl",
     "net_components/layers/pool.jl",
-    "net_components/layers/relu.jl"
+    "net_components/layers/relu.jl",
+    "net_components/layers/skip_unit.jl",
+    "net_components/layers/zero.jl",
     ]
 Public  = false
 ```

--- a/docs/src/net_components/nets.md
+++ b/docs/src/net_components/nets.md
@@ -1,22 +1,27 @@
 # Networks
+
 Each network corresponds to an array of layers associated with a unique string identifier. The string identifier of the network is used to store cached models, so it's important to ensure that you don't re-use names!
 
 ## Public Interface
+
 ```@autodocs
 Modules = [MIPVerify]
 Order   = [:function, :type]
 Pages   = [
     "net_components/nets/sequential.jl",
+    "net_components/nets/skip_sequential.jl",
     ]
 Private = false
 ```
 
 ## Internal
+
 ```@autodocs
 Modules = [MIPVerify]
 Order   = [:function, :type]
 Pages   = [
     "net_components/nets/sequential.jl",
+    "net_components/nets/skip_sequential.jl",
     ]
 Public  = false
 ```


### PR DESCRIPTION
We were pinning the version of Documenter.jl to `0.23`, which seemed to be causing problems. Upgrading to 0.27 as a quick fix for now.

In addition, we identified some docstrings that were excluded from the docs and add them back in.
