### PR TITLE
Silence output from solvers for tightening and during testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
         version:
           # we are excluding nightly builds because they can fail, and we want this to be a
           # required check
-          - "1.0" # minimum Julia version that this package supports
+          - "1.6" # minimum Julia version that this package supports
           - "1" # automatically expands to latest stable 1.x release of Julia
         os:
           - ubuntu-latest
@@ -36,12 +36,6 @@ jobs:
           - windows-latest
         arch:
           - x64
-        include:
-          # for x86, we have to pin the version to 1.0 as the HDF5 package does not compile on the
-          # latest stable 1.x version
-          - os: ubuntu-latest
-            version: "1.0"
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/MIPVerify.jl
+++ b/src/MIPVerify.jl
@@ -98,6 +98,7 @@ function find_adversarial_example(
     tightening_algorithm::TighteningAlgorithm = DEFAULT_TIGHTENING_ALGORITHM,
     tightening_options::Dict = get_default_tightening_options(optimizer),
     solve_if_predicted_in_targeted = true,
+    silence_solve_output::Bool = false,
 )::Dict
 
     total_time = @elapsed begin
@@ -150,7 +151,11 @@ function find_adversarial_example(
             end
             set_optimizer(m, optimizer)
             set_optimizer_attributes(m, main_solve_options...)
-            optimize!(m)
+            if silence_solve_output
+                optimize_silent!(m)
+            else
+                optimize!(m)
+            end
             d[:SolveStatus] = JuMP.termination_status(m)
             d[:SolveTime] = JuMP.solve_time(m)
         end

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -18,6 +18,14 @@ function is_constant(x::JuMP.VariableRef)
     false
 end
 
+function optimize_silent!(m)
+    redirect_stdout(devnull) do
+        optimize!(m)
+        # Required, per https://discourse.julialang.org/t/consistent-way-to-suppress-solver-output/20437/9
+        Base.Libc.flush_cstdio()
+    end
+end
+
 function get_tightening_algorithm(
     x::JuMPLinearType,
     nta::Union{TighteningAlgorithm,Nothing},
@@ -86,7 +94,7 @@ arithmetic, as a backup.
 """
 function tight_bound_helper(m::Model, bound_type::BoundType, objective::JuMPLinearType, b_0::Number)
     @objective(m, bound_obj[bound_type], objective)
-    optimize!(m)
+    optimize_silent!(m)
     status = JuMP.termination_status(m)
     if status == MathOptInterface.OPTIMAL
         b = JuMP.objective_value(m)

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -75,6 +75,7 @@ function test_find_adversarial_example(
         tightening_options = get_tightening_options(),
         tightening_algorithm = TEST_DEFAULT_TIGHTENING_ALGORITHM,
         invert_target_selection = invert_target_selection,
+        silence_solve_output = true,
     )
     if isnan(expected_objective_value)
         @test d[:SolveStatus] == MathOptInterface.INFEASIBLE ||

--- a/test/net_components/core_ops.jl
+++ b/test/net_components/core_ops.jl
@@ -21,7 +21,8 @@ using MIPVerify:
     TighteningAlgorithm,
     MIPVerifyExt,
     upper_bound,
-    lower_bound
+    lower_bound,
+    optimize_silent!
 @isdefined(TestHelpers) || include("../TestHelpers.jl")
 
 function count_binary_variables(m::Model)
@@ -102,7 +103,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             @test count_binary_variables(m) == 0
 
             @objective(m, Max, x1)
-            optimize!(m)
+            optimize_silent!(m)
             solve_output = JuMP.value(xmax)
             @test solve_output ≈ 3
         end
@@ -121,7 +122,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
 
             # elements of the input array are made to take their maximum value
             @objective(m, Max, x1 + x2 + x3 + x4 + x5)
-            optimize!(m)
+            optimize_silent!(m)
 
             solve_output = JuMP.value(xmax)
             @test solve_output ≈ 7
@@ -161,7 +162,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
 
             # elements of the input array are made to take their maximum value
             @objective(m, Max, xmax)
-            optimize!(m)
+            optimize_silent!(m)
 
             solve_output = JuMP.value(xmax)
             @test solve_output ≈ 100
@@ -176,7 +177,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             # no binary variables need to be introduced
             @test count_binary_variables(m) == 0
 
-            optimize!(m)
+            optimize_silent!(m)
 
             solve_output = JuMP.value(xmax)
             @test solve_output ≈ 2
@@ -193,7 +194,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             @test count_binary_variables(m) == 0
 
             @objective(m, Max, x1)
-            optimize!(m)
+            optimize_silent!(m)
             solve_output = JuMP.value(xmax)
             @test solve_output ≈ 3
         end
@@ -266,7 +267,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @test count_binary_variables(m) == 0
 
                 @objective(m, Max, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 1
             end
             @testset "strictly non-positive" begin
@@ -278,7 +279,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @test count_binary_variables(m) == 0
 
                 @objective(m, Max, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 1
             end
             @testset "regular" begin
@@ -290,7 +291,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @test count_binary_variables(m) <= 1
 
                 @objective(m, Max, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 2
             end
         end
@@ -305,7 +306,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @test count_binary_variables(m) == 0
 
                 @objective(m, Max, x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 0
             end
             @testset "strictly non-positive" begin
@@ -348,13 +349,13 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @test count_binary_variables(m) == 0
 
                 @objective(m, Max, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 1
                 @test JuMP.value(x) ≈ -1
                 @test JuMP.value(x_r) ≈ 0
 
                 @objective(m, Min, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ -2
                 @test JuMP.value(x) ≈ 2
                 @test JuMP.value(x_r) ≈ 0
@@ -368,13 +369,13 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @test count_binary_variables(m) <= 1
 
                 @objective(m, Max, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 2
                 @test JuMP.value(x) ≈ 2
                 @test JuMP.value(x_r) ≈ 2
 
                 @objective(m, Min, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 0
                 @test JuMP.value(x) ≈ 0
                 @test JuMP.value(x_r) ≈ 0
@@ -388,13 +389,13 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @test count_binary_variables(m) == 0
 
                 @objective(m, Max, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 2
                 @test JuMP.value(x) ≈ 2
                 @test JuMP.value(x_r) ≈ 2
 
                 @objective(m, Min, 2 * x_r - x)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ -1
                 @test JuMP.value(x) ≈ -1
                 @test JuMP.value(x_r) ≈ -1
@@ -415,13 +416,13 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 x_r = masked_relu(x, [-1, 0, 1])
 
                 @objective(m, Max, sum(2 * x_r - x))
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 5
                 @test JuMP.value.(x) ≈ [-1, 2, 2]
                 @test JuMP.value.(x_r) ≈ [0, 2, 2]
 
                 @objective(m, Min, sum(2 * x_r - x))
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ -3
                 @test JuMP.value.(x) ≈ [2, 0, -1]
                 @test JuMP.value.(x_r) ≈ [0, 0, -1]
@@ -439,7 +440,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             @test count_binary_variables(m) == 0
 
             @objective(m, Max, 2 * x_a - x)
-            optimize!(m)
+            optimize_silent!(m)
             @test JuMP.objective_value(m) ≈ 1
         end
         @testset "strictly non-positive" begin
@@ -451,7 +452,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             @test count_binary_variables(m) == 0
 
             @objective(m, Max, 2 * x_a - x)
-            optimize!(m)
+            optimize_silent!(m)
             @test JuMP.objective_value(m) ≈ 3
         end
         @testset "regular" begin
@@ -463,7 +464,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             @test count_binary_variables(m) == 0
 
             @objective(m, Max, 2 * x_a - x)
-            optimize!(m)
+            optimize_silent!(m)
             @test JuMP.objective_value(m) ≈ 6
         end
         @testset "abs_ge is not strict" begin
@@ -476,7 +477,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             @test count_binary_variables(m) == 0
 
             @objective(m, Min, x_a - x)
-            optimize!(m)
+            optimize_silent!(m)
             @test JuMP.objective_value(m) ≈ 0
         end
     end
@@ -499,7 +500,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @constraint(m, x[3] == 1)
                 set_max_indexes(m, x, [1])
                 @objective(m, Min, x[1])
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.value(x[1]) ≈ 5
             end
             @testset "with margin" begin
@@ -510,7 +511,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 @constraint(m, x[3] == 1)
                 set_max_indexes(m, x, [1], margin = margin)
                 @objective(m, Min, x[1])
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.value(x[1]) ≈ 5 + margin
             end
         end
@@ -525,7 +526,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 set_upper_bound(x[3], 10)
                 set_max_indexes(m, x, [2, 3])
                 @objective(m, Min, x[2] + x[3])
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.value(x[2]) ≈ 5
                 @test JuMP.value(x[3]) ≈ -1
             end
@@ -540,7 +541,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                 set_upper_bound(x[3], 10)
                 set_max_indexes(m, x, [2, 3], margin = margin)
                 @objective(m, Min, x[2] + x[3])
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.value(x[2]) ≈ 5 + margin
                 @test JuMP.value(x[3]) ≈ -1
             end
@@ -551,7 +552,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                     x2 = @variable(m, lower_bound = 4, upper_bound = 5)
                     set_max_indexes(m, [x1, x2], [2])
                     @objective(m, Min, x2)
-                    optimize!(m)
+                    optimize_silent!(m)
                     @test JuMP.value(x2) ≈ 4
                 end
                 @testset "selected variable has non-constant value, and cannot take the maximum value" begin
@@ -560,7 +561,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                     x2 = @variable(m, lower_bound = -5, upper_bound = -4)
                     set_max_indexes(m, [x1, x2], [2])
                     @objective(m, Min, x2)
-                    optimize!(m)
+                    optimize_silent!(m)
                     solve_status = JuMP.termination_status(m)
                     @test (
                         solve_status in
@@ -573,7 +574,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                     x2 = @variable(m, lower_bound = -5, upper_bound = -4)
                     set_max_indexes(m, [x1, x2], [1])
                     @objective(m, Min, x2)
-                    optimize!(m)
+                    optimize_silent!(m)
                     @test JuMP.value(x2) ≈ -5
                 end
                 @testset "selected variable has constant value, and cannot take the maximum value" begin
@@ -582,7 +583,7 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                     x2 = @variable(m, lower_bound = 4, upper_bound = 5)
                     set_max_indexes(m, [x1, x2], [1])
                     @objective(m, Min, x2)
-                    optimize!(m)
+                    optimize_silent!(m)
                     solve_status = JuMP.termination_status(m)
                     @test (
                         solve_status in

--- a/test/net_components/layers/conv2d.jl
+++ b/test/net_components/layers/conv2d.jl
@@ -1,7 +1,7 @@
 using Test
 using JuMP
 using MIPVerify
-using MIPVerify: check_size
+using MIPVerify: check_size, optimize_silent!
 @isdefined(TestHelpers) || include("../../TestHelpers.jl")
 
 function test_convolution_layer(
@@ -53,7 +53,7 @@ function test_convolution_layer(
         p_v = MIPVerify.Conv2d(filter_v, bias_v, p.stride, p.padding)
         output_v = MIPVerify.conv2d(input, p_v)
         @constraint(m, output_v .== expected_output)
-        optimize!(m)
+        optimize_silent!(m)
 
         p_solve = MIPVerify.Conv2d(JuMP.value.(filter_v), JuMP.value.(bias_v), p.stride, p.padding)
         solve_output = MIPVerify.conv2d(input, p_solve)
@@ -64,7 +64,7 @@ function test_convolution_layer(
         input_v = map(_ -> @variable(m), CartesianIndices(input_size))
         output_v = MIPVerify.conv2d(input_v, p)
         @constraint(m, output_v .== expected_output)
-        optimize!(m)
+        optimize_silent!(m)
 
         solve_output = MIPVerify.conv2d(JuMP.value.(input_v), p)
         @test solve_output ≈ expected_output

--- a/test/net_components/layers/linear.jl
+++ b/test/net_components/layers/linear.jl
@@ -1,6 +1,6 @@
 using Test
 using JuMP
-using MIPVerify: Linear, check_size
+using MIPVerify: Linear, check_size, optimize_silent!
 @isdefined(TestHelpers) || include("../../TestHelpers.jl")
 
 @testset "linear.jl" begin
@@ -58,7 +58,7 @@ using MIPVerify: Linear, check_size
                 y = @variable(m)
                 @constraint(m, x == 7)
                 @constraint(m, y == 8)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.value.(p([x, y])) == [28, 59]
             end
         end

--- a/test/net_components/layers/pool.jl
+++ b/test/net_components/layers/pool.jl
@@ -1,6 +1,7 @@
 using Test
 using JuMP
 using MIPVerify
+using MIPVerify: optimize_silent!
 @isdefined(TestHelpers) || include("../../TestHelpers.jl")
 
 @testset "pool.jl" begin
@@ -54,7 +55,7 @@ using MIPVerify
             pool_v = MIPVerify.pool(input_array_v, MaxPool((2, 2)))
             # elements of the input array are made to take their maximum value
             @objective(m, Max, sum(input_array_v))
-            optimize!(m)
+            optimize_silent!(m)
 
             solve_output = JuMP.value.(pool_v)
             @test solve_output ≈ true_output

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using Cbc
 using JuMP
 
-using MIPVerify: set_log_level!
+using MIPVerify: set_log_level!, optimize_silent!
 using MIPVerify: get_max_index, get_norm, get_default_tightening_options
 
 @isdefined(TestHelpers) || include("TestHelpers.jl")
@@ -53,19 +53,19 @@ using MIPVerify: get_max_index, get_norm, get_default_tightening_options
                 n_inf = get_norm(Inf, xs)
 
                 @objective(m, Min, n_1)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 6
 
                 if Base.find_package("Gurobi") !== nothing
                     # Skip these tests if Gurobi is not installed.
                     # Cbc does not solve problems with quadratic objectives
                     @objective(m, Min, n_2)
-                    optimize!(m)
+                    optimize_silent!(m)
                     @test JuMP.objective_value(m) ≈ 14
                 end
 
                 @objective(m, Min, n_inf)
-                optimize!(m)
+                optimize_silent!(m)
                 @test JuMP.objective_value(m) ≈ 3
 
                 @test_throws DomainError get_norm(3, xs)


### PR DESCRIPTION
Silence output from solvers 1) for tightening and 2) during all testing via the solution outlined in https://github.com/jump-dev/JuMP.jl/issues/1883#issuecomment-1434120039.

The key function is `optimize_silent!`, which is a wrapper on top of `optimize!`.

```
function optimize_silent!(m)
    redirect_stdout(devnull) do
        optimize!(m)
        # Required, per https://discourse.julialang.org/t/consistent-way-to-suppress-solver-output/20437/9
        Base.Libc.flush_cstdio()
    end
end
```

We bump the minimum required Julia version to 1.6 since https://github.com/JuliaLang/julia/pull/36146 (which allows `redirect_stdout(devnull)` to work cross-platform) is only found in 1.6.0 and later. This necessitates dropping `x86` support, since the `HDF5` package (which we use to import data) does not compile in 1.6; see https://github.com/vtjeng/MIPVerify.jl/actions/runs/4201127640/jobs/7287828526#step:6:303.