### PR TITLE
Bump minimum Julia version to 1.6.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ MathOptInterface = "0.9, 0.10, 1"
 Memento = "0.12, 0.13, 1"
 ProgressMeter = "1"
 TimerOutputs = "0.5"
-julia = "1"
+julia = "1.6"
 
 [extras]
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"


### PR DESCRIPTION
With https://github.com/vtjeng/MIPVerify.jl/commit/41b3805a1d7c4c84e1330a1dcb8509e66f1594b1, we should have increased the minimum Julia version to 1.6, since our tests were failing at 1.5 and below. We do so in this PR, and will cut a new `MIPVerify` version ASAP.

(I can't figure out why we needed to bump it to 1.6, but it was clearly necessary for tests to pass. Possibly a JuMP.jl / HiGHS.jl thing?)