### PR TITLE
Allow PRs that reduce patch coverage.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,7 @@
-comment: false
+# source: https://docs.codecov.com/docs/commit-status
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 10%


### PR DESCRIPTION
We still require that PRs improve overall coverage.

Also, we allow Codecov to comment on our PRs -- that is helpful so we can save a click.
