### PR TITLE
Change direct access of `.lo` and `.hi` fields to function calls to `inf` and `sup`.

### DIFF
--- a/src/vendor/ConditionalJuMP.jl
+++ b/src/vendor/ConditionalJuMP.jl
@@ -42,5 +42,5 @@ lower_bound(x::JuMP.VariableRef) = JuMP.lower_bound(x)
 upper_bound(x::JuMP.VariableRef) = JuMP.upper_bound(x)
 lower_bound(e::JuMP.GenericAffExpr) = lower_bound(IntervalArithmetic.interval(e))
 upper_bound(e::JuMP.GenericAffExpr) = upper_bound(IntervalArithmetic.interval(e))
-lower_bound(i::Interval) = i.lo
-upper_bound(i::Interval) = i.hi
+lower_bound(i::Interval) = inf(i)
+upper_bound(i::Interval) = sup(i)


### PR DESCRIPTION
This PR is expected to be a no-op.

## Motivation

This is necessary since the `.hi` field appears to be no longer available in `0.22`: https://github.com/vtjeng/MIPVerify.jl/pull/146#issuecomment-1855248801

## Testing

`inf` and `sup` have been available in the `IntervalArithmetic.jl` package since `0.15`, which is the earliest version of `IntervalArithmetic.jl` our package supports: https://github.com/JuliaIntervals/IntervalArithmetic.jl/blob/e19764302e41c1b619b2a50727586be4ff90b6c7/src/IntervalArithmetic.jl#L55.
