### PR TITLE
document behavior of find_adversarial_example in producing 'ties'

### DIFF
--- a/src/MIPVerify.jl
+++ b/src/MIPVerify.jl
@@ -147,7 +147,7 @@ function find_adversarial_example(
                 # details.
                 v_obj = @variable(m)
                 @constraint(m, v_obj == maximum_target_var - maximum_nontarget_var)
-                @constraint(m, v_obj >= 0)
+                @constraint(m, v_obj > 0)
                 @objective(m, Max, v_obj)
             else
                 error("Unknown adversarial_example_objective $adversarial_example_objective")

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -527,7 +527,7 @@ end
 $(SIGNATURES)
 
 Imposes constraints ensuring that one of the elements at the target_indexes is the
-largest element of the array x. More specifically, we require `x[j] - x[i] ≥ margin` for
+largest element of the array x. More specifically, we require `x[j] - x[i] > margin` for
 some `j ∈ target_indexes` and for all `i ∉ target_indexes`.
 """
 function set_max_indexes(
@@ -539,6 +539,6 @@ function set_max_indexes(
 
     (maximum_target_var, nontarget_vars) = get_vars_for_max_index(xs, target_indexes)
 
-    @constraint(model, nontarget_vars .<= maximum_target_var - margin)
+    @constraint(model, nontarget_vars .< maximum_target_var - margin)
     return nothing
 end

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -526,8 +526,8 @@ end
 """
 $(SIGNATURES)
 
-Imposes constraints ensuring that one of the elements at the target_indexes is the
-largest element of the array x. More specifically, we require `x[j] - x[i] > margin` for
+Imposes constraints ensuring that one of the elements at the target_indexes is (tied for) the
+largest element of the array x. More specifically, we require `x[j] - x[i] ≥ margin` for
 some `j ∈ target_indexes` and for all `i ∉ target_indexes`.
 """
 function set_max_indexes(
@@ -539,6 +539,9 @@ function set_max_indexes(
 
     (maximum_target_var, nontarget_vars) = get_vars_for_max_index(xs, target_indexes)
 
-    @constraint(model, nontarget_vars .< maximum_target_var - margin)
+    # JuMP does not support strict inequalities; see 
+    # https://github.com/jump-dev/JuMP.jl/blob/24c0409c5fa5cae6a4ae64b1c82ab5f83d55fbc6/src/macros/%40variable.jl#L516-L523
+    # for more context.
+    @constraint(model, nontarget_vars .<= maximum_target_var - margin)
     return nothing
 end


### PR DESCRIPTION
This PR is intended as a step in the right direction for #159. We may need to reinstate (optional) tolerances for users.