### PR TITLE
Update example Jupyter notebooks.

### DIFF
--- a/examples/00_quickstart.ipynb
+++ b/examples/00_quickstart.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This notebook demonstrates how you can find adversarial examples for a pre-trained example network on the MNIST dataset.\n",
     "\n",
-    "We suggest having the `Gurobi` solver installed, since its performance is significantly faster. If this is not possible, the `Cbc` solver is another option.\n",
+    "We suggest having the `Gurobi` solver installed, since its performance is significantly faster. If this is not possible, the `HiGHS` solver is another option.\n",
     "\n",
     "The `Images` package is only necessary for visualizing the sample images."
    ]
@@ -17,21 +17,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "┌ Info: Precompiling MIPVerify [e5e5f8be-2a6a-5994-adbb-5afbd0e30425]\n",
-      "└ @ Base loading.jl:1260\n",
-      "┌ Info: Precompiling Images [916415d5-f1e6-5110-898d-aaa5f9f070e0]\n",
-      "└ @ Base loading.jl:1260\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "using MIPVerify\n",
-    "using Gurobi\n",
+    "# If you have an academic license, use `Gurobi` instead.\n",
+    "using HiGHS\n",
     "using Images"
    ]
   },
@@ -63,9 +53,8 @@
        "    `labels`: 10000 corresponding labels, with 10 unique labels in [0, 9]."
       ]
      },
-     "execution_count": 2,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -85,9 +74,8 @@
        "    `labels`: 60000 corresponding labels, with 10 unique labels in [0, 9]."
       ]
      },
-     "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -105,9 +93,8 @@
        "(60000, 28, 28, 1)"
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -122,7 +109,7 @@
     {
      "data": {
       "text/plain": [
-       "60000-element Array{UInt8,1}:\n",
+       "60000-element Vector{UInt8}:\n",
        " 0x05\n",
        " 0x00\n",
        " 0x04\n",
@@ -133,13 +120,7 @@
        " 0x03\n",
        " 0x01\n",
        " 0x04\n",
-       " 0x03\n",
-       " 0x05\n",
-       " 0x03\n",
        "    ⋮\n",
-       " 0x07\n",
-       " 0x08\n",
-       " 0x09\n",
        " 0x02\n",
        " 0x09\n",
        " 0x05\n",
@@ -151,9 +132,8 @@
        " 0x08"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -186,9 +166,8 @@
        "  (6) Linear(20 -> 10)\n"
       ]
      },
-     "execution_count": 6,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -208,21 +187,13 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32mComputing fraction correct...100%|██████████████████████| Time: 0:00:02\u001b[39m\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
        "0.9695"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -246,7 +217,7 @@
     {
      "data": {
       "text/plain": [
-       "1×28×28×1 Array{Float64,4}:\n",
+       "1×28×28×1 Array{Float64, 4}:\n",
        "[:, :, 1, 1] =\n",
        " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
        "\n",
@@ -256,7 +227,7 @@
        "[:, :, 3, 1] =\n",
        " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
        "\n",
-       "...\n",
+       ";;; … \n",
        "\n",
        "[:, :, 26, 1] =\n",
        " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
@@ -268,9 +239,8 @@
        " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0"
       ]
      },
-     "execution_count": 8,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -285,7 +255,7 @@
     {
      "data": {
       "text/plain": [
-       "10-element Array{Float64,1}:\n",
+       "10-element Vector{Float64}:\n",
        " -0.02074390040759505\n",
        " -0.017499541361042703\n",
        "  0.16707187742051954\n",
@@ -298,9 +268,8 @@
        "  0.40145201599055125"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -325,9 +294,8 @@
        "7"
       ]
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -352,9 +320,8 @@
        "7"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -367,7 +334,7 @@
    "source": [
     "## Finding an Adversarial Example\n",
     "\n",
-    "We now try to find the closest $L_infty$ norm adversarial example to the first image, setting the target category as index `10` (corresponding to a true label of 9). Note that we restrict the search space to a distance of `0.05` around the original image via the specified `pp`."
+    "We now try to find the closest $L_{\\infty}$ norm adversarial example to the first image, setting the target category as index `10` (corresponding to a true label of 9). Note that we restrict the search space to a distance of `0.05` around the original image via the specified `pp`."
    ]
   },
   {
@@ -379,122 +346,67 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating upper bounds:  10%|██▎                    |  ETA: 0:02:41\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:26\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:08\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Gurobi Optimizer version 9.0.2 build v9.0.2rc0 (linux64)\n",
-      "Optimize a model with 3249 rows, 2405 columns and 54806 nonzeros\n",
-      "Model fingerprint: 0x64c1ce1f\n",
-      "Variable types: 2379 continuous, 26 integer (26 binary)\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [1e-05, 3e+01]\n",
-      "  Objective range  [1e+00, 1e+00]\n",
-      "  Bounds range     [5e-03, 1e+01]\n",
-      "  RHS range        [4e-03, 3e+01]\n",
-      "Presolve removed 2263 rows and 1564 columns\n",
-      "Presolve time: 0.16s\n",
-      "Presolved: 986 rows, 841 columns, 45508 nonzeros\n",
-      "Variable types: 815 continuous, 26 integer (26 binary)\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1770 rows, 1621 cols, 51874 nonzeros\n",
+      "1770 rows, 1621 cols, 51874 nonzeros\n",
       "\n",
-      "Root relaxation: objective 6.198262e-04, 1141 iterations, 0.07 seconds\n",
+      "Solving MIP model with:\n",
+      "   1770 rows\n",
+      "   1621 cols (26 binary, 0 integer, 0 implied int., 1595 continuous)\n",
+      "   51874 nonzeros\n",
       "\n",
-      "    Nodes    |    Current Node    |     Objective Bounds      |     Work\n",
-      " Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "     0     0    0.00062    0   16          -    0.00062      -     -    0s\n",
-      "     0     0    0.00524    0   18          -    0.00524      -     -    0s\n",
-      "     0     0    0.00545    0   18          -    0.00545      -     -    0s\n",
-      "     0     0    0.00568    0   18          -    0.00568      -     -    0s\n",
-      "     0     0    0.00569    0   18          -    0.00569      -     -    0s\n",
-      "     0     0    0.00570    0   18          -    0.00570      -     -    0s\n",
-      "     0     0    0.00570    0   18          -    0.00570      -     -    0s\n",
-      "     0     0    0.00572    0   18          -    0.00572      -     -    0s\n",
-      "     0     0    0.00572    0   18          -    0.00572      -     -    0s\n",
-      "     0     0    0.00572    0   18          -    0.00572      -     -    0s\n",
-      "H    0     0                       0.0462748    0.00572  87.6%     -    1s\n",
-      "     0     2    0.00573    0   17    0.04627    0.00573  87.6%     -    1s\n",
-      "H   59     2                       0.0460847    0.04270  7.35%  71.8    2s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0.000619835635  inf                  inf        0      0      8      2021     0.1s\n",
+      "         0       0         0   0.00%   0.00338385518   inf                  inf     5652     14     30      2097     5.2s\n",
+      "         0       0         0   0.00%   0.00343896617   inf                  inf     5989     12     38     40946    25.4s\n",
+      " B      15       0         3  12.55%   0.00343896617   0.0460846816      92.54%     5994     12     47     55284    28.3s\n",
       "\n",
-      "Cutting planes:\n",
-      "  MIR: 10\n",
-      "  RLT: 3\n",
-      "\n",
-      "Explored 70 nodes (5782 simplex iterations) in 2.53 seconds\n",
-      "Thread count was 4 (of 4 available processors)\n",
-      "\n",
-      "Solution count 2: 0.0460847 0.0462748 \n",
-      "\n",
-      "Optimal solution found (tolerance 1.00e-04)\n",
-      "Best objective 4.608468158892e-02, best bound 4.608468158892e-02, gap 0.0000%\n"
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.0460846815889\n",
+      "  Dual bound        0.0460846815889\n",
+      "  Gap               0% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.0460846815889 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    0 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            32.80 (total)\n",
+      "                    0.02 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             27\n",
+      "  LP iterations     60751 (total)\n",
+      "                    14654 (strong br.)\n",
+      "                    751 (separation)\n",
+      "                    38835 (heuristics)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 2.52689\n",
-       "  :TotalTime          => 55.0765\n",
-       "  :Perturbation       => JuMP.VariableRef[noname noname … noname noname]…\n",
-       "  :PerturbedInput     => JuMP.VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 32.8068\n",
+       "  :TotalTime          => 60.2054\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[785] _[786] … _[811] _[812];;; _[813] _[814] … _[83…\n",
        "  :TighteningApproach => \"mip\"\n",
        "  :PerturbationFamily => linf-norm-bounded-0.05\n",
        "  :SolveStatus        => OPTIMAL\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => JuMP.GenericAffExpr{Float64,JuMP.VariableRef}[-0.01206…\n",
+       "  :Output             => JuMP.AffExpr[-0.012063867412507534 _[1601] + 0.0758192…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 12,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -503,7 +415,7 @@
     "    n1, \n",
     "    sample_image, \n",
     "    target_label_index, \n",
-    "    Gurobi.Optimizer, \n",
+    "    HiGHS.Optimizer, \n",
     "    Dict(),\n",
     "    norm_order = Inf,\n",
     "    pp=MIPVerify.LInfNormBoundedPerturbationFamily(0.05)\n",
@@ -518,7 +430,7 @@
     {
      "data": {
       "text/plain": [
-       "1×28×28×1 Array{Float64,4}:\n",
+       "1×28×28×1 Array{Float64, 4}:\n",
        "[:, :, 1, 1] =\n",
        " 0.0460847  0.0  0.0  0.0460847  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0460847\n",
        "\n",
@@ -528,7 +440,7 @@
        "[:, :, 3, 1] =\n",
        " 0.0  0.0  0.0  0.0  0.0  0.0  0.0460847  …  0.0  0.0  0.0460847  0.0  0.0\n",
        "\n",
-       "...\n",
+       ";;; … \n",
        "\n",
        "[:, :, 26, 1] =\n",
        " 0.0  0.0  0.0460847  0.0  0.0  0.0  0.0  …  0.0460847  0.0460847  0.0  0.0\n",
@@ -540,9 +452,8 @@
        " 0.0460847  0.0  0.0460847  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0460847  0.0"
       ]
      },
-     "execution_count": 13,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -566,22 +477,21 @@
     {
      "data": {
       "text/plain": [
-       "10-element Array{Float64,1}:\n",
-       "  0.6749450628745557\n",
+       "10-element Vector{Float64}:\n",
+       "  0.6749450628745558\n",
        "  0.6179790360668576\n",
        "  0.3930321598089386\n",
        "  0.29656185967035986\n",
-       "  0.2410105349548306\n",
-       "  0.16060021203574193\n",
+       "  0.2410105349548307\n",
+       "  0.1606002120357421\n",
        "  0.5428526100447275\n",
        "  4.288351484573889\n",
-       " -0.22643018233076273\n",
+       " -0.2264301823307634\n",
        "  4.288351484573882"
       ]
      },
-     "execution_count": 14,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -592,7 +502,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We visualize the perturbed image and compare it to the original image. Since we are minimizing the $L_infty$-norm, changes are made to many pixels but the change to each pixels is not very noticeable."
+    "We visualize the perturbed image and compare it to the original image. Since we are minimizing the $L_{\\infty}$-norm, changes are made to many pixels but the change to each pixels is not very noticeable."
    ]
   },
   {
@@ -602,9 +512,12 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAALHSURBVGje7dq/r0xBFAfwz/LiVx4FiQh5OhIaEREFhY5QKJQaGhWN0EgU/gydSCQanYhQiB9BJRHxM2hQ0L4tJCQU915vdnbm7ja792WyJ9nszNxzZnK/35wzM+fc3jz6BmW+/u8H7Vw/tusn7MOxFaYs5S84F/IQ8hnzE4/PR/9abMPn5UM6fQ7DTuMvfwz7Upv/xf7ZzDEX9Bud8iGd+oK9kKtG2mJiTlIxN6VfPqTdxNIwLuZ8rD9iolxM7vwNy1+wF+I9yidH8SiaR8KmfEinzyGDmJM+T4Y89xM2Ir1YGrvyIZ1+LM1xcghX8BK/cLMe/5SZKPblcEzwrHxIu/FDhrH/iTV1fz0W69+blsm24Bsu4L20z5YPaXfn0lD6OIA9eIvd2IvD2IavWAj0/2AlNtT9a7gonRMoH9LlwSFp/BdUXN7BfpUT/1XF2o94h404hxu1Xbyflg9p97G07bzSPI9t4CSu4wt2YZX0ebZ8SLvjsJFx+It1NuM11uE0brfYlw9pt7k28n6Y46+Pqyr+fuNDxq6zNyx/wd44+bS22sVB3Kvbx/FYPt528oblLzhQtxjnHh+PHav/X+B5i97sTDMxGdgPc9zl+FyLp9iJI3iW0JndDycucwzXjVJxNcXjJRV/Tyzxl8vTzWrAE5OBu8U4Oe2Gi+O4he84gwfStarZfjhxGfLDlMT1/dW4XPfvqvhj2G9F/Vm+dCKSvOOPkofYh884ih8j9Gf74USll6sz5GLrVlU+G06o+Ixt2s5G5UPabR0/lBR/m3C/bl+yxF/DWdv3VM03OeVD2s1+mLqTx3dFOIvtdftRYDMqxxrOWT6kyyPX1kgYE3fgvKVaoowe7ZyWD2l3HOa+q2nGD9XtRdVZJnV3zOVUO33D8hf8z2EuTxr71CucUtXrY722dtMvH9LllfNu4yMl49iXD+nUF/wHg+y5HmmDeFIAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
@@ -615,13 +528,7 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " ⋮                         ⋱  \n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)        …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
@@ -633,9 +540,8 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 15,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -649,9 +555,12 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAGrSURBVGje7dk/a9VQHIfxT711EFysKDhYOzl0KSKCoILiYtuhg30L10U7dnZ3dPAddBEEQRERKuigDl1E7T+8HVREEOqghaKFOiRDKVy9aUp78uN8l5z8IQ8PX06SQ8jJycnJycnJycnJyamfvm4nJtHGV6xjBt/wsSbwwF4bxgd27XAFQ9uO/cSH/9zwC+5gLhXD+MD+bifaGME8hnEGl3Een3Fyy7Ub+I4T5f4nucM9TF+Vi48oupzDuS3H17GMBQzgFu6lYhgfWKnDf+U67uM9rmA1FcP4wF3p8DjeldtJPEjJMD6wv/4tuIlj+IGl1AzjA2vPwwt4joOKb56XqRnGB9aeh2OK/mbxOkXD+MBaHR7CNfzGbfxJ0TA+sFaH04q1xlO8StUwPnDH78NxPMQaRvX2HN0Xw/jAHc3Do7iLFp7ovb99MYwPrDwPW3iDs+go3oedlA3jAyt3eBqL5XgCj1I3jA+s9Cw9hWfleBqPm2AYH1ipwxsYLMcvsNkEw/jAnju8hKkmGsYH9tzhRRwuxx38aophfGDltcVbXNX931JyhvGBOc3PX/q9Oc17OzXKAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAdBJREFUaAW9wb1qlgcABtCDeToUXLRU6FB/cOtSgggFWyh0EV0EvYXUoXQpBFxCQYdAxg7egeAFlBIKKXTRJYv4UyrGwYoIhQS0Q1ChDu8QBL/4vfnCc06URVmURVmURVmURVmURVmURVmURVmURVmURVmURVmURVmURVmURVmURVlMcAkLeIZt3MBzPDKbKIuyKIsJVnDcjst4ift29xQrWPd+URZlURYTLOBLPMAXmMe3+Ar/4HM73uBffGbwBOveL8qiLMpigjWsGawaHMI81nHajm08xF84jMcmi7Ioi7IYYQt/GKx510Ucwl3cNFmURVmUxT44gus4gKvYNFmURVmUxT74AZ9iC3/bXZRFWZTFjM7gisEF3LO7KIuyKIsZncNHWMNtHxZlURZlMYOPcRav8DNe+7Aoi7IoixksYh6ruGU6URZlURZ7dB5LeIFrphdlURZlsQef4BfM4TfcNr0oi7Ioi5HmsIoT2MCScaIsyqIsRjqJUwY/YcM4URZlURYjHMPvBov41XhRFmVRFiN8j6MGf+J/40VZlEVZTOkb/Gh2URZlURZT+hoHDTbwn72JsiiLshjpDr7Dpr2JsiiLspjSMpbNLsqiLMreApamPWWOWvFrAAAAAElFTkSuQmCC",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAdBJREFUaAW9wb1qlgcABtCDeToUXLRU6FB/cOtSgggFWyh0EV0EvYXUoXQpBFxCQYdAxg7egeAFlBIKKXTRJYv4UyrGwYoIhQS0Q1ChDu8QBL/4vfnCc06URVmURVmURVmURVmURVmURVmURVmURVmURVmURVmURVmURVmURVmURVlMcAkLeIZt3MBzPDKbKIuyKIsJVnDcjst4ift29xQrWPd+URZlURYTLOBLPMAXmMe3+Ar/4HM73uBffGbwBOveL8qiLMpigjWsGawaHMI81nHajm08xF84jMcmi7Ioi7IYYQt/GKx510Ucwl3cNFmURVmUxT44gus4gKvYNFmURVmUxT74AZ9iC3/bXZRFWZTFjM7gisEF3LO7KIuyKIsZncNHWMNtHxZlURZlMYOPcRav8DNe+7Aoi7IoixksYh6ruGU6URZlURZ7dB5LeIFrphdlURZlsQef4BfM4TfcNr0oi7Ioi5HmsIoT2MCScaIsyqIsRjqJUwY/YcM4URZlURYjHMPvBov41XhRFmVRFiN8j6MGf+J/40VZlEVZTOkb/Gh2URZlURZT+hoHDTbwn72JsiiLshjpDr7Dpr2JsiiLspjSMpbNLsqiLMreApamPWWOWvFrAAAAAElFTkSuQmCC\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
@@ -660,15 +569,9 @@
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " ⋮                                       ⋱  \n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
@@ -680,9 +583,8 @@
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 16,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -699,15 +601,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.4.2",
+   "display_name": "Julia 1.7.1",
    "language": "julia",
-   "name": "julia-1.4"
+   "name": "julia-1.7"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.4.2"
+   "version": "1.7.1"
   }
  },
  "nbformat": 4,

--- a/examples/01_importing_your_own_neural_net.ipynb
+++ b/examples/01_importing_your_own_neural_net.ipynb
@@ -25,7 +25,8 @@
    "outputs": [],
    "source": [
     "using MIPVerify\n",
-    "using Gurobi\n",
+    "# If you have an academic license, use `Gurobi` instead.\n",
+    "using HiGHS\n",
     "using MAT"
    ]
   },
@@ -44,7 +45,7 @@
     {
      "data": {
       "text/plain": [
-       "Dict{String,Any} with 20 entries:\n",
+       "Dict{String, Any} with 20 entries:\n",
        "  \"fc1/weight\"           => Float32[-0.75335 -0.702841 … -0.0350578 -0.284728; …\n",
        "  \"logits/bias/Adam_1\"   => Float32[3.17918f-5 1.73752f-5 … 7.47935f-5 4.50664f…\n",
        "  \"logits/bias/Adam\"     => Float32[-0.000917174 0.000822852 … -0.00134091 -0.0…\n",
@@ -67,9 +68,8 @@
        "  \"fc2/bias/Adam_1\"      => Float32[7.38528f-6 5.92213f-6 … 1.58686f-6 4.14633f…"
       ]
      },
-     "execution_count": 2,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -107,7 +107,7 @@
     {
      "data": {
       "text/plain": [
-       "784×40 Array{Float32,2}:\n",
+       "784×40 Matrix{Float32}:\n",
        " -0.75335   -0.702841   0.00934679   0.0424287   …  -0.0350578   -0.284728\n",
        " -1.26091   -0.975876  -0.0690286   -0.145539       -0.139512    -0.494751\n",
        " -1.30244   -1.54214   -0.063707    -0.306707       -0.0144018   -0.644423\n",
@@ -118,13 +118,7 @@
        " -0.991218  -0.86704   -0.036489    -0.0409108       0.0330326   -0.472234\n",
        " -1.09089   -1.31528   -0.0488595    0.00274563     -0.160661    -0.603701\n",
        " -1.0728    -1.15951   -0.0882954   -0.10305        -0.138768    -0.700878\n",
-       " -0.703903  -0.736082  -0.0991159   -0.0173509   …  -0.0374209   -0.25564\n",
-       " -1.35577   -1.31734   -0.110668    -0.145239       -0.163263    -0.791115\n",
-       " -0.633791  -0.653072  -0.0239808    0.0591085       0.0185225   -0.322362\n",
        "  ⋮                                              ⋱               \n",
-       " -2.43389   -1.91281   -0.181009     0.185867        0.220844    -0.786262\n",
-       " -2.26904   -1.57718   -0.0287671    0.158107       -0.112781    -0.806248\n",
-       " -2.00159   -1.50079    0.00412571   0.0239607      -0.221186    -0.629596\n",
        " -1.42311   -1.20815   -0.0115304    0.111935    …  -0.41617     -0.518008\n",
        " -1.9324    -1.53047   -0.109568    -0.0240137      -0.608832    -1.12603\n",
        " -1.51948   -1.42803    0.248483    -0.0787689      -0.0857386   -0.729084\n",
@@ -136,9 +130,8 @@
        " -0.963221  -0.951116  -0.0672328   -0.0266708       0.137328    -0.312931"
       ]
      },
-     "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -153,13 +146,12 @@
     {
      "data": {
       "text/plain": [
-       "1×40 Array{Float32,2}:\n",
+       "1×40 Matrix{Float32}:\n",
        " 0.763984  0.215094  4.37897  -0.164343  …  4.89644  -0.702274  2.13576"
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -186,9 +178,8 @@
        "Linear(784 -> 40)"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -215,9 +206,8 @@
        "Linear(784 -> 40)"
       ]
      },
-     "execution_count": 6,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -228,14 +218,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`get_matrix_params` requires that 1) you specify the expected size of the layer, and 2) your weight and bias arrays following the naming convention outlined in the [documentation](https://vtjeng.github.io/MIPVerify.jl/stable/utils/import_weights.html#MIPVerify.get_matrix_params-Tuple{Dict{String,V} where V,String,Tuple{Int64,Int64}})."
+    "`get_matrix_params` requires that 1) you specify the expected size of the layer, and 2) your weight and bias arrays following the naming convention outlined in the [documentation](https://vtjeng.com/MIPVerify.jl/stable/utils/import_weights/#MIPVerify.get_matrix_params-Tuple{Dict{String},%20String,%20Tuple{Int64,%20Int64}})."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a sanity check, you can verify that the parameters we get from both methods are equal."
+    "As a quick check, you can verify that the parameters we get from both methods are equal."
    ]
   },
   {
@@ -249,9 +239,8 @@
        "true"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -269,9 +258,8 @@
        "true"
       ]
      },
-     "execution_count": 8,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -298,9 +286,8 @@
        "Linear(40 -> 20)"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -318,9 +305,8 @@
        "Linear(20 -> 10)"
       ]
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -353,9 +339,8 @@
        "  (6) Linear(20 -> 10)\n"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -380,15 +365,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.4.2",
+   "display_name": "Julia 1.7.1",
    "language": "julia",
-   "name": "julia-1.4"
+   "name": "julia-1.7"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.4.2"
+   "version": "1.7.1"
   }
  },
  "nbformat": 4,

--- a/examples/02_finding_adversarial_examples_in_depth.ipynb
+++ b/examples/02_finding_adversarial_examples_in_depth.ipynb
@@ -20,14 +20,13 @@
        "view_diff (generic function with 1 method)"
       ]
      },
-     "execution_count": 1,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
     "using MIPVerify\n",
-    "using Gurobi\n",
+    "using HiGHS\n",
     "using JuMP\n",
     "using Images\n",
     "using Printf\n",
@@ -64,16 +63,18 @@
     "It also takes named arguments, each with the default value specified.\n",
     "\n",
     "```\n",
-    "norm_order = 1\n",
     "invert_target_selection = false\n",
     "pp = MIPVerify.UnrestrictedPerturbationFamily()\n",
+    "norm_order = 1\n",
+    "adversarial_example_objective = closest\n",
     "tightening_algorithm = mip\n",
     "tightening_options: same as main solver, but with output suppressed and a time limit of 20s per solve.\n",
+    "solve_if_predicted_in_targeted = true\n",
     "```\n",
     "\n",
-    "See [full documentation here](https://vtjeng.github.io/MIPVerify.jl/dev/finding_adversarial_examples/single_image/#MIPVerify.find_adversarial_example-Tuple{NeuralNet,Array{#s165,N}%20where%20N%20where%20#s165%3C:Real,Union{Integer,%20Array{#s164,1}%20where%20#s164%3C:Integer},Any,Dict}).\n",
+    "See [full documentation here](https://vtjeng.com/MIPVerify.jl/dev/finding_adversarial_examples/single_image/#MIPVerify.find_adversarial_example-Tuple{NeuralNet,%20Array{%3C:Real},%20Union{Integer,%20Vector{%3C:Integer}},%20Any,%20Dict}).\n",
     "\n",
-    "We explore what each of these options allow us to do."
+    "We explore what some of these options allow us to do."
    ]
   },
   {
@@ -105,57 +106,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [9]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating upper bounds:  10%|██▎                    |  ETA: 0:02:50\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:19\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Objective Value: 0.104073, Solve Time: 531.95\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Objective Value: 0.104073, Solve Time: 105.14\n"
      ]
     }
    ],
@@ -164,10 +117,9 @@
     "    n1, \n",
     "    sample_image, \n",
     "    9, \n",
-    "    Gurobi.Optimizer,\n",
-    "    # OutputFlag=0 prevents any output from being printed out\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
-    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.15),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
+    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.105),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
     ")\n",
@@ -183,42 +135,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  40%|█████████▎             |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Objective Value: 0.046085, Solve Time: 44.76\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Objective Value: 0.046085, Solve Time: 281.74\n"
      ]
     }
    ],
@@ -227,9 +146,9 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10, \n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
-    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.15),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
+    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.105),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
     ")\n",
@@ -254,42 +173,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [9, 10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  10%|██▎                    |  ETA: 0:00:01\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Objective Value: 0.046085, Solve Time: 24.28\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Objective Value: 0.046085, Solve Time: 545.51\n"
      ]
     }
    ],
@@ -298,9 +184,9 @@
     "    n1, \n",
     "    sample_image, \n",
     "    [9, 10], \n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
-    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.15),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
+    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.105),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
     ")\n",
@@ -323,44 +209,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [1, 2, 3, 4, 5, 6, 7, 9, 10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  25%|█████▊                 |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Objective Value: 0.046085, Solve Time: 102.45\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Objective Value: 0.046085, Solve Time: 2708.19\n"
      ]
     }
    ],
@@ -369,9 +220,9 @@
     "    n1, \n",
     "    sample_image, \n",
     "    [1, 2, 3, 4, 5, 6, 7, 9, 10], \n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
-    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.15),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
+    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.105),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
     ")\n",
@@ -394,44 +245,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [1, 2, 3, 4, 5, 6, 7, 9, 10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  25%|█████▊                 |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Objective Value: 0.046085, Solve Time: 107.32\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Objective Value: 0.046085, Solve Time: 2711.58\n"
      ]
     }
    ],
@@ -440,9 +256,9 @@
     "    n1, \n",
     "    sample_image, \n",
     "    8, \n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
-    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.15),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
+    "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.105),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
     "    invert_target_selection = true,\n",
@@ -470,50 +286,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  15%|███▌                   |  ETA: 0:00:01\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      " 46.896601 seconds (4.36 M allocations: 177.896 MiB)\n",
-      "Objective Value: 0.046085, Solve Time: 44.07\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "546.409633 seconds (4.17 M allocations: 191.573 MiB, 0.17% compilation time)\n",
+      "Objective Value: 0.046085, Solve Time: 545.13\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAALHSURBVGje7dq/r0xBFAfwz/LiVx4FiQh5OhIaEREFhY5QKJQaGhWN0EgU/gydSCQanYhQiB9BJRHxM2hQ0L4tJCQU915vdnbm7ja792WyJ9nszNxzZnK/35wzM+fc3jz6BmW+/u8H7Vw/tusn7MOxFaYs5S84F/IQ8hnzE4/PR/9abMPn5UM6fQ7DTuMvfwz7Upv/xf7ZzDEX9Bud8iGd+oK9kKtG2mJiTlIxN6VfPqTdxNIwLuZ8rD9iolxM7vwNy1+wF+I9yidH8SiaR8KmfEinzyGDmJM+T4Y89xM2Ir1YGrvyIZ1+LM1xcghX8BK/cLMe/5SZKPblcEzwrHxIu/FDhrH/iTV1fz0W69+blsm24Bsu4L20z5YPaXfn0lD6OIA9eIvd2IvD2IavWAj0/2AlNtT9a7gonRMoH9LlwSFp/BdUXN7BfpUT/1XF2o94h404hxu1Xbyflg9p97G07bzSPI9t4CSu4wt2YZX0ebZ8SLvjsJFx+It1NuM11uE0brfYlw9pt7k28n6Y46+Pqyr+fuNDxq6zNyx/wd44+bS22sVB3Kvbx/FYPt528oblLzhQtxjnHh+PHav/X+B5i97sTDMxGdgPc9zl+FyLp9iJI3iW0JndDycucwzXjVJxNcXjJRV/Tyzxl8vTzWrAE5OBu8U4Oe2Gi+O4he84gwfStarZfjhxGfLDlMT1/dW4XPfvqvhj2G9F/Vm+dCKSvOOPkofYh884ih8j9Gf74USll6sz5GLrVlU+G06o+Ixt2s5G5UPabR0/lBR/m3C/bl+yxF/DWdv3VM03OeVD2s1+mLqTx3dFOIvtdftRYDMqxxrOWT6kyyPX1kgYE3fgvKVaoowe7ZyWD2l3HOa+q2nGD9XtRdVZJnV3zOVUO33D8hf8z2EuTxr71CucUtXrY722dtMvH9LllfNu4yMl49iXD+nUF/wHg+y5HmmDeFIAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
@@ -524,13 +310,7 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " ⋮                         ⋱  \n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)        …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
@@ -542,9 +322,8 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -552,8 +331,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10, \n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order = Inf,\n",
     ")\n",
@@ -587,49 +366,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  25%|█████▊                 |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      " 41.363017 seconds (2.07 M allocations: 68.034 MiB)\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "546.924763 seconds (1.90 M allocations: 72.457 MiB)\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAALHSURBVGje7dq/r0xBFAfwz/LiVx4FiQh5OhIaEREFhY5QKJQaGhWN0EgU/gydSCQanYhQiB9BJRHxM2hQ0L4tJCQU915vdnbm7ja792WyJ9nszNxzZnK/35wzM+fc3jz6BmW+/u8H7Vw/tusn7MOxFaYs5S84F/IQ8hnzE4/PR/9abMPn5UM6fQ7DTuMvfwz7Upv/xf7ZzDEX9Bud8iGd+oK9kKtG2mJiTlIxN6VfPqTdxNIwLuZ8rD9iolxM7vwNy1+wF+I9yidH8SiaR8KmfEinzyGDmJM+T4Y89xM2Ir1YGrvyIZ1+LM1xcghX8BK/cLMe/5SZKPblcEzwrHxIu/FDhrH/iTV1fz0W69+blsm24Bsu4L20z5YPaXfn0lD6OIA9eIvd2IvD2IavWAj0/2AlNtT9a7gonRMoH9LlwSFp/BdUXN7BfpUT/1XF2o94h404hxu1Xbyflg9p97G07bzSPI9t4CSu4wt2YZX0ebZ8SLvjsJFx+It1NuM11uE0brfYlw9pt7k28n6Y46+Pqyr+fuNDxq6zNyx/wd44+bS22sVB3Kvbx/FYPt528oblLzhQtxjnHh+PHav/X+B5i97sTDMxGdgPc9zl+FyLp9iJI3iW0JndDycucwzXjVJxNcXjJRV/Tyzxl8vTzWrAE5OBu8U4Oe2Gi+O4he84gwfStarZfjhxGfLDlMT1/dW4XPfvqvhj2G9F/Vm+dCKSvOOPkofYh884ih8j9Gf74USll6sz5GLrVlU+G06o+Ixt2s5G5UPabR0/lBR/m3C/bl+yxF/DWdv3VM03OeVD2s1+mLqTx3dFOIvtdftRYDMqxxrOWT6kyyPX1kgYE3fgvKVaoowe7ZyWD2l3HOa+q2nGD9XtRdVZJnV3zOVUO33D8hf8z2EuTxr71CucUtXrY722dtMvH9LllfNu4yMl49iXD+nUF/wHg+y5HmmDeFIAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
@@ -640,13 +389,7 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " ⋮                         ⋱  \n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)        …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
@@ -658,9 +401,8 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 8,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -668,8 +410,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf,\n",
     ")\n",
@@ -686,47 +428,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      " 14.070512 seconds (2.93 M allocations: 95.636 MiB)\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      " 21.179666 seconds (2.99 M allocations: 102.860 MiB, 0.07% compilation time)\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAALHSURBVGje7dq/r0xBFAfwz/LiVx4FiQh5OhIaEREFhY5QKJQaGhWN0EgU/gydSCQanYhQiB9BJRHxM2hQ0L4tJCQU915vdnbm7ja792WyJ9nszNxzZnK/35wzM+fc3jz6BmW+/u8H7Vw/tusn7MOxFaYs5S84F/IQ8hnzE4/PR/9abMPn5UM6fQ7DTuMvfwz7Upv/xf7ZzDEX9Bud8iGd+oK9kKtG2mJiTlIxN6VfPqTdxNIwLuZ8rD9iolxM7vwNy1+wF+I9yidH8SiaR8KmfEinzyGDmJM+T4Y89xM2Ir1YGrvyIZ1+LM1xcghX8BK/cLMe/5SZKPblcEzwrHxIu/FDhrH/iTV1fz0W69+blsm24Bsu4L20z5YPaXfn0lD6OIA9eIvd2IvD2IavWAj0/2AlNtT9a7gonRMoH9LlwSFp/BdUXN7BfpUT/1XF2o94h404hxu1Xbyflg9p97G07bzSPI9t4CSu4wt2YZX0ebZ8SLvjsJFx+It1NuM11uE0brfYlw9pt7k28n6Y46+Pqyr+fuNDxq6zNyx/wd44+bS22sVB3Kvbx/FYPt528oblLzhQtxjnHh+PHav/X+B5i97sTDMxGdgPc9zl+FyLp9iJI3iW0JndDycucwzXjVJxNcXjJRV/Tyzxl8vTzWrAE5OBu8U4Oe2Gi+O4he84gwfStarZfjhxGfLDlMT1/dW4XPfvqvhj2G9F/Vm+dCKSvOOPkofYh884ih8j9Gf74USll6sz5GLrVlU+G06o+Ixt2s5G5UPabR0/lBR/m3C/bl+yxF/DWdv3VM03OeVD2s1+mLqTx3dFOIvtdftRYDMqxxrOWT6kyyPX1kgYE3fgvKVaoowe7ZyWD2l3HOa+q2nGD9XtRdVZJnV3zOVUO33D8hf8z2EuTxr71CucUtXrY722dtMvH9LllfNu4yMl49iXD+nUF/wHg+y5HmmDeFIAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
@@ -737,13 +451,7 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " ⋮                         ⋱  \n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)        …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
@@ -755,9 +463,8 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -765,8 +472,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf,\n",
     "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.05)\n",
@@ -791,49 +498,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "  0.631356 seconds (2.27 M allocations: 75.066 MiB)\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "  0.336244 seconds (2.75 M allocations: 91.080 MiB, 20.55% gc time)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 0.233993\n",
-       "  :TotalTime          => 0.609287\n",
-       "  :Perturbation       => VariableRef[noname noname … noname noname]…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 0.0551291\n",
+       "  :TotalTime          => 0.336011\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[785] _[786] … _[811] _[812];;; _[813] _[814] … _[83…\n",
        "  :TighteningApproach => \"lp\"\n",
        "  :PerturbationFamily => linf-norm-bounded-0.03\n",
-       "  :SolveStatus        => INFEASIBLE_OR_UNBOUNDED\n",
+       "  :SolveStatus        => INFEASIBLE\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[0.0014746447222673…\n",
+       "  :Output             => AffExpr[0.0014746447222673583 _[785] + 0.0086289714433…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -841,8 +529,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf,\n",
     "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.03)\n",
@@ -857,12 +545,11 @@
     {
      "data": {
       "text/plain": [
-       "INFEASIBLE_OR_UNBOUNDED::TerminationStatusCode = 6"
+       "INFEASIBLE::TerminationStatusCode = 2"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -887,49 +574,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  10%|██▎                    |  ETA: 0:00:01\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      " 48.396935 seconds (4.98 M allocations: 216.330 MiB, 0.18% gc time)\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "164.483624 seconds (4.45 M allocations: 210.833 MiB, 0.56% compilation time)\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAKQSURBVGje7drbSlRRHMfxj3lI7ahlRQeyA4V0EUFFEEh40TN401XP0Xt00xv0AkEQ3hRBN0JdVKAlJZiV1ZiHcpou/ks0p3BroHsW84cNe+1ZzG9++8t/rf9aa2hGM5rRjGY0oxnNaPxoWfvgME5gIbWnsIg5VNOz2n8I7thqh/kL1jEcRFe6b08dqphNz2r+znAB4/iWPq/+o1/+r3TLBdvWPniBPdiNC9iJffgs+KyOGn6kPkS+VgT3ZY7b7jB/wTqGn9J1wwqzL4LrElqtMFpmeFXkbHe6xgTzUjjMX7COYTvOiDmxDR/xQXDtQKcYNztT/370CmaLOCLmzumyOMxfsI5hJ65gV2ofw1Erdc1efBXjaweupy8ZxzW8xGiZHOYvWMdwHiOC1Sx60Cfya7/IwQOp72kxF86l+1Mi/ybL5DB/wTqGS5hY1X4j5r8uKznYK9guipwbxR0xPz4Tc2RpHOYv2FakU03k2lxqvxe1y6Soe84LxuN4XjaH+QsWYrg2WnEw3VcxLHLynqh9SuUwf8FNMewX42oFF0UOvsLbMjrMX3DDDPvE2mN5DT8kap+7mCmjw/wFN8SwHQOixpnBJbGf80TkYSkd5i9YmGELLotxc17k4KCoae7jV1kd5i9YmGG3mAOJuvRWaj9SPAe3xWH+goUYdokcJNYPN8VezjuRg6V2mL9gIYbHxR5ci8jHITGWPvDnfkApHeYvuC7DHpxM94dwW3AcwcNGcJi/YCGGremXnRXn/NMiByuN4DB/wUJj6Q5xdjEg9mGeivX8Zv6Tkf8rLR/DMbEvOizOmmbxGj8bxWH+gusybBVniOdSu4LH+N4oDvMXXJdhm6hlJsQ51JRY4zeMw/wFfwP9nHz9VPH8aQAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAoJJREFUaAW9wctqnAUcB9CT5pfLjO3UVHuhtdiLWIoLEVoRBJEufIZuXPkcvocb36AvUBCkG0VwE9CFEZo22ECNSW0SJ5nY8XPxLcRJ05nJ4n9OFItiUSyKRbEoFsWiWBSLYlEsikWxKBbFolgUi2JRLIrFiPO4jH2tpxigj6FW4/iiWBSLYjHiBjpac7iKIXa1GjQO28cqttFgiMZhUSyKRbEY8TNO4STewwJOYwvb/q/BARa0BtjBDBoMHRbFolgUixGb2MSn2Nb6E6fwArOYQYMGB/gQc+iii4fY8nJRLIpFsRgxh+u4jOAP/I5NzGMR+1jUuoIz2MIAF9DHhpeLYlEsisWIRdzGa1qXcBED9NHDc5zGPD5GsIqP8AuWHS2KRbEoFiP28AA97GIJZ3EBr2Mfb2hdwwL6uIar2MC6o0WxKBbFYsQLrPnPI8yggx6e4wyWMMAylvElGvyIA0eLYlEsisUEGvTR13qCLtaxjRvoYBU/ebUoFsWiWBzDLN7UGuIuBvgam14tikWxKBbHcAU97OB9dLCCx8aLYlEsisWUzuI6GgxxB7v4Cs+MF8WiWBSLKczhJmbwDB/gJL7HislEsSgWxWJCM7iFDvYwxCfYxj38YzJRLIpFsZhQFz2tJ/gcPXyLFZOLYlEsisUEOriltYrPcBu/4Z7pRLEoFsViAm9hETPo4g6GuI8104liUSyKxRhLeFvrHL5AFw/wjelFsSgWxWKMJcziBN7BeWzgPnZML4pFsSgWEziBi7iJTfyAx2hML4pFsSgWYzzEOu5iHrv4FX87nigWxaJYjDGLS3hXawff4S/HE8WiWBSLMYJzWMMjPMWe44tiUSyK/QteL33mEIZTIgAAAABJRU5ErkJggg==",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAoJJREFUaAW9wctqnAUcB9CT5pfLjO3UVHuhtdiLWIoLEVoRBJEufIZuXPkcvocb36AvUBCkG0VwE9CFEZo22ECNSW0SJ5nY8XPxLcRJ05nJ4n9OFItiUSyKRbEoFsWiWBSLYlEsikWxKBbFolgUi2JRLIrFiPO4jH2tpxigj6FW4/iiWBSLYjHiBjpac7iKIXa1GjQO28cqttFgiMZhUSyKRbEY8TNO4STewwJOYwvb/q/BARa0BtjBDBoMHRbFolgUixGb2MSn2Nb6E6fwArOYQYMGB/gQc+iii4fY8nJRLIpFsRgxh+u4jOAP/I5NzGMR+1jUuoIz2MIAF9DHhpeLYlEsisWIRdzGa1qXcBED9NHDc5zGPD5GsIqP8AuWHS2KRbEoFiP28AA97GIJZ3EBr2Mfb2hdwwL6uIar2MC6o0WxKBbFYsQLrPnPI8yggx6e4wyWMMAylvElGvyIA0eLYlEsisUEGvTR13qCLtaxjRvoYBU/ebUoFsWiWBzDLN7UGuIuBvgam14tikWxKBbHcAU97OB9dLCCx8aLYlEsisWUzuI6GgxxB7v4Cs+MF8WiWBSLKczhJmbwDB/gJL7HislEsSgWxWJCM7iFDvYwxCfYxj38YzJRLIpFsZhQFz2tJ/gcPXyLFZOLYlEsisUEOriltYrPcBu/4Z7pRLEoFsViAm9hETPo4g6GuI8104liUSyKxRhLeFvrHL5AFw/wjelFsSgWxWKMJcziBN7BeWzgPnZML4pFsSgWEziBi7iJTfyAx2hML4pFsSgWYzzEOu5iHrv4FX87nigWxaJYjDGLS3hXawff4S/HE8WiWBSLMYJzWMMjPMWe44tiUSyK/QteL33mEIZTIgAAAABJRU5ErkJg\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
@@ -938,15 +595,9 @@
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " ⋮                                       ⋱  \n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
@@ -958,9 +609,8 @@
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 12,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -968,8 +618,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf,\n",
     "    pp = MIPVerify.BlurringPerturbationFamily((5, 5))\n",
@@ -985,7 +635,10 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAMAAADxPgR5AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAABv1BMVEX5+Pne8fzE5PnL6Prg8vzn9f3v+f7x+f7x+v663/ey2vas1/Wr1/Wu2fW73/e74Pe84PfE5Pji8/zu+P7X7vv/3NP/q5r/yLv/2tHY7vvO6fqs2PWy2/bL6Pnt+P3xaVndTUDiU0XuZFTqXU7/k4H/lIL/kYD/hnT/wrP/xbj/no3/moj/4trw+f7P6vrc8Pv/7Ob/zsL/ppXvZVXwZ1fyaln/opH/pJPkVkfkVUf/rp7y+v7o9f2bzfKPxu+Qxu+Xy/G03PbV7fvW7fvQ6vqVyfCJwe2g0PP/qZnzbFvZ7vvH5vmZzPGRx++azfFpquJIi85Sltb/vrD/r5//7+vq9v3r9/3b7/vM6Pr/yr7/vK3/6uPS6/q/4vj/2c//wbP/sqL/5uD/9PD/v7H/u6z/7unU7Pu+4fj/w7X/2tDp9v3h8vzK5/n/3tX/vq//6+XC4/j/6OH/wLL/zcHA4vj/5+D/tqb/wLH/6uTl9Pz/sKD/08f/wrT/8/Cx2vb/uqrk9Py13Pa53/f/0sav2fX/9fKw2fXR6/r/va7+hHL/39bs9/3/tKT9gW//5N3/0cXu+P2Rx/Cp1fTm9f3///8TIqe1AAAAAWJLR0SUf2dKFQAAAidJREFUaN7t2utTTVEch/GkokRSSEVFKbnkmuTalSJyq1xKFApFSi5FJNdu6B/2fGf2mvHivGjG2rM38/u8OXOaOfPsPbNaZ621T1KSMcYYY8x/aAWSsTKQglSkYRVWw4LxDqYjI7AGmViLdYEsrE8gGxuQA3dxFowmqA/lYiM2YTPysAX5cBeh1wIUIjOwFdsCilowmqBThOJACbZjB0pRBr3uRDkqsAuV2I092AsLRhPUP+4+VGE/9P4ADuIQdAGH4S7mCKpxFDU4hlochwWjCZ7ASZz6w2mcQR3qoYm9AY1oQjPO4hxaoEG07NFpQe9BTbqt0AJKk/h5aIK+gDZchLuQS2jHZehL+Aqu4hosGF0wES1+r0OL5A50ogsaSBpg+vsN3MQt/FXMgqEEE7kNTQDd6MEd9OIuLBj/oBZICil4D33ox32EcncW9O4BFHsILXoHMIhHsGD8g49RGHiCIQzjKUK5Owt6pY2NDoc0YJ5hBM8ximUfBFkwsqAWUmNQTNEXGMdLvIL3u7Og96AmZndw+xpvoAEzAe8xC3qPaQPjDt/15auD20no8PYtLBj/oNu4vIM2plPQ4leTufeYBb3H3uMDFJvGR2jAaEOjg0ALxj/oDmRn8AlaMGnzqY2o9wfQFgwt+BlfoI3nV3zDd3iPWTCUoMxCh3baeM5hHguw4L8R1IMTLZz0Ix4FF/EDod2dBb3TgNFhrB5u/cQvLMGCsQn+BvCtkF4ovvyqAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAIAAABJgmMcAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAABN1JREFUeAHtwctvXHcVwPHvvXPuzHj8GMfx2HnIUDdGKpEqXqIg0fJQIkBVV+xYIbb8C+zhv2DBP0FVkBoF1KoCFZUK1ERN+kiauHViZxw/Zu6dOz9W5ziL2Tg6dibS+XxkOBgS/AjBlRBcCcGVEFwJwZUQXAnBlRBcCcGVEFwJwZUQXAnBlRBcCcGVEFwJwZUQXAnBlXBMXwwbqHuPa1RLMibpdXJUq5Gh2pKhcp6QYdrjiueNEFwJwZUQXAnH9PF2hRpUiUnKOqE+3cE0csx8M2eiDJPx9NqSob7WFdRckaOyDJNzpJ0qnpYQXAnBlRBcCcf00nKB2q8S6qXtjzAfvItZW8csraBudC+jDqqEur1doRJHMp6QYZqNDDUcJSZpSYaaXcxQKXEky/AgBFdCcCUEV8IxrRY1psDs/v4PqAd37zNJ0SxQK2e6qNGwRH3nle9hsgyTEmacMPt7mFd/gmkUmHf/ixlVmF/+CtVf3cCDEFwJwZUQXAnHtE+B+mx3hJr/459Rl0ZbqJ25c6gz//sH5qMPUY/evoa6/dbbqLMXVlEP733JJL2186j5T29j8hz1xZtvYRLm4vIKKn9jA5N4akJwJQRXQnAlHFNZJ9S/7gxQe8OaIzMc6aMyXka1vvEt1Norv0WtnylQ1x9WqI2zBaqsE+rNTw5Qe4Matdpton5TNFF7f7+OWe6hWuMKD0JwJQRXQnAlHFNLMtSP12dQu2VCzTUz1KPBGLW1X6Pu9yvUra0h6l6/Qu0Px6hbD4aom3cfoz757AGqM9tG/e71dUxvFTV35Srm5R/iTQiuhOBKCK6EY+qkCvVChyMdnpAwHcxguY0ajlqovSqh5psZ6tFgjOoPE6pd5KjvXlpEXdnooNZvXMeMa8yPrqLKmQW8CcGVEFwJwZVwitrjCtXOMd0WEy3MYG6MMtTFboGab+eo9c0PMYf7mIN9zKjmJAnBlRBcCcGVMMUOswL18LBkkp8uDTD//BwzqjCv/gJVdhY5SUJwJQRXQnAlTLG7j2vU48EYNdfKMdtfYUQwF7+O+qq9jFpkxEkSgishuBKCK2HKbJYN1O2dEpNh5poZ5rDCVCXmTA+1mI84LUJwJQRXQnAlTIF9CtTNh0NMwizO5KjvZ5uYz29hukuo3YXzqHaqOC1CcCUEV0JwJTwjg7xA/WezRB1WCTVTZKjXZBPz/juYzixm7RKqnSqeBSG4EoIrIbgSnpHBKKF2B2MmudwrMH+7hllcwpztocqFHs+aEFwJwZUQXAmnaDcJ6oMvSyZ5calAXfjLnzCrFzDNFuaFbzJNhOBKCK6E4Eo4Rff3atSgSqjEkZVOjukuYuoatfPtK6hZKqaJEFwJwZUQXAknbGvUQN3pl6jEkXaRoXofv4dpd1D9H7yOKkcJNdtgqgjBlRBcCcGVcML6w4Sqx5hxSqifr4ww2xVmOEB1q11U1lzAjJkqQnAlBFdCcCWconFKqBeXCsz71zDlEJXeeweVbVxGtc/PMK2E4EoIroTgSjhhG7Nj1GqnjTq7cwdTlZjDA1Sqa1RWtHgeCMGVEFwJwZVwwg6yArW5V6Oq7hrqHP/GrK2j+ld/jZplxPNACK6E4EoIroQTVo8TauugRv315h4qn/kZ6pwI6rUaM9vguSAEV0JwJQRX/wcBM0r6snQxfwAAAABJRU5ErkJggg==",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAIAAABJgmMcAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAABN1JREFUeAHtwctvXHcVwPHvvXPuzHj8GMfx2HnIUDdGKpEqXqIg0fJQIkBVV+xYIbb8C+zhv2DBP0FVkBoF1KoCFZUK1ERN+kiauHViZxw/Zu6dOz9W5ziL2Tg6dibS+XxkOBgS/AjBlRBcCcGVEFwJwZUQXAnBlRBcCcGVEFwJwZUQXAnBlRBcCcGVEFwJwZUQXAnBlXBMXwwbqHuPa1RLMibpdXJUq5Gh2pKhcp6QYdrjiueNEFwJwZUQXAnH9PF2hRpUiUnKOqE+3cE0csx8M2eiDJPx9NqSob7WFdRckaOyDJNzpJ0qnpYQXAnBlRBcCcf00nKB2q8S6qXtjzAfvItZW8csraBudC+jDqqEur1doRJHMp6QYZqNDDUcJSZpSYaaXcxQKXEky/AgBFdCcCUEV8IxrRY1psDs/v4PqAd37zNJ0SxQK2e6qNGwRH3nle9hsgyTEmacMPt7mFd/gmkUmHf/ixlVmF/+CtVf3cCDEFwJwZUQXAnHtE+B+mx3hJr/459Rl0ZbqJ25c6gz//sH5qMPUY/evoa6/dbbqLMXVlEP733JJL2186j5T29j8hz1xZtvYRLm4vIKKn9jA5N4akJwJQRXQnAlHFNZJ9S/7gxQe8OaIzMc6aMyXka1vvEt1Norv0WtnylQ1x9WqI2zBaqsE+rNTw5Qe4Matdpton5TNFF7f7+OWe6hWuMKD0JwJQRXQnAlHFNLMtSP12dQu2VCzTUz1KPBGLW1X6Pu9yvUra0h6l6/Qu0Px6hbD4aom3cfoz757AGqM9tG/e71dUxvFTV35Srm5R/iTQiuhOBKCK6EY+qkCvVChyMdnpAwHcxguY0ajlqovSqh5psZ6tFgjOoPE6pd5KjvXlpEXdnooNZvXMeMa8yPrqLKmQW8CcGVEFwJwZVwitrjCtXOMd0WEy3MYG6MMtTFboGab+eo9c0PMYf7mIN9zKjmJAnBlRBcCcGVMMUOswL18LBkkp8uDTD//BwzqjCv/gJVdhY5SUJwJQRXQnAlTLG7j2vU48EYNdfKMdtfYUQwF7+O+qq9jFpkxEkSgishuBKCK2HKbJYN1O2dEpNh5poZ5rDCVCXmTA+1mI84LUJwJQRXQnAlTIF9CtTNh0NMwizO5KjvZ5uYz29hukuo3YXzqHaqOC1CcCUEV0JwJTwjg7xA/WezRB1WCTVTZKjXZBPz/juYzixm7RKqnSqeBSG4EoIrIbgSnpHBKKF2B2MmudwrMH+7hllcwpztocqFHs+aEFwJwZUQXAmnaDcJ6oMvSyZ5calAXfjLnzCrFzDNFuaFbzJNhOBKCK6E4Eo4Rff3atSgSqjEkZVOjukuYuoatfPtK6hZKqaJEFwJwZUQXAknbGvUQN3pl6jEkXaRoXofv4dpd1D9H7yOKkcJNdtgqgjBlRBcCcGVcML6w4Sqx5hxSqifr4ww2xVmOEB1q11U1lzAjJkqQnAlBFdCcCWconFKqBeXCsz71zDlEJXeeweVbVxGtc/PMK2E4EoIroTgSjhhG7Nj1GqnjTq7cwdTlZjDA1Sqa1RWtHgeCMGVEFwJwZVwwg6yArW5V6Oq7hrqHP/GrK2j+ld/jZplxPNACK6E4EoIroQTVo8TauugRv315h4qn/kZ6pwI6rUaM9vguSAEV0JwJQRX/wcBM0r6snQxfwAAAABJRU5ErkJg\">"
+      ],
       "text/plain": [
        "28×28 Array{RGB{Float64},2} with eltype RGB{Float64}:\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
@@ -998,13 +651,7 @@
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " ⋮                                         ⋱  \n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
@@ -1016,9 +663,8 @@
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)"
       ]
      },
-     "execution_count": 13,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1046,49 +692,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  10%|██▎                    |  ETA: 0:00:01\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Objective Value: 4.641859, Solve Time: 55.99\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Objective Value: 4.641859, Solve Time: 364.94\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAHWSURBVGje7dm7axRRHMXxjyYpBBsNChY+KgstJIggJIKPRmNhYf6FpFHLgH+CWFpY2NsIQiAiIihEfBVpJL4xFioiCFqokEKIxYywkey644TdOz/vaebuzDBfzpw9l3sZsrKy+q11VW4+jws1get77TA+MKv56tjDBxhdY2D8WuQeZmX9h2o7l05gEh+xhKv4hDc1gfGntp4D22b4Frv+OPcNz/7ywA+4iPlUHMYHDra7MIl9eI49GMFhHMR7bG+59yc+Y1v5+52cYQ+1oofLOi9UNymynMeBlvNLeI0X2IyzuJyKw/jASnv8TjqNa3iKI/iSisP4wDXJcCsWyuMErqfkMD5wsP4jOIMt+IpXqTmMD6zdw1HcxZBizXMvNYfxgbV7OK7I7w4erXJ9Clf66TA+sFYPN+A+9uIoHqboMD6wVg+nFXuNW7rLb7kfDuMD/7mHJzGDHzhh9Xn0t1r3nfFfaTN6OIxLGMBNnfNj5R8l/itNv4cDeIz9WMTx8pisw/jAyhnuxstyfAqzqTuMD6w0l+7E7XI8jRtNcBgfWCnDKewox3OKtUryDuMDu87wEM410WF8YNcZjmFjOV7E96Y4jA+svLd4gmPaf1tKzmF8YFbz9QuU8T8T+c3qhwAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAfNJREFUaAW9wbGLlgUAB+Dny19D0KJh0FAabi1yhBBcQdAitQj6L2hDtASCiwQ1KI4ODe5Bf0DEEVzQkLfcEpVidA0aIQQK1iAqXMM7fIp+n/fee/yeJ8qiLMqiLMqiLMqiLEY4h4umibIoi7IY4aLpoizKoiyW+Amr9laURVmUxRKr9l6URVmURVmURVmUxQKncBp/4z6+xm38YZooi7IoiwUu4bC5j/EvfrPcX7iETc8WZVEWZbHAaRzFNbyFFbyPd3ALr5t7hH/wmsFNbHq2KIuyKIvHbGNmsI51gzWD/VjBJo6Zu4/fcR0H8KfFoizKoiweM7PcXfxgsO5JJ7Efv+Abi0VZlEVZ7IFX8RVewBe4Y7Eoi7Ioiz3wCQ7iLm5YLsqiLMpiolWcMziBXy0XZVEWZTHRh3gR69jwtDO4Yi7KoizKYoKXcBwP8DkeetoVT4qyKIuymOAsVrCGq55vG1EWZVEWu/QRzuMevrTcNmaYIcqiLMpiF17BZezDd9iw3MxclEVZlMVI+7CGN7GF88aJsiiLshjpCN42+AxbxomyKIuyGOEQvjc4i2+NF2VRFmUxwhm8YfAjto0XZVEWZbFD7+FT00VZlEVZ7NC7eNlgC//ZnSiLsiiLkX7GB7hjd6IsyqIsdugCLpguyqIsyv4HjP9ExGhQSGUAAAAASUVORK5CYII=",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAfNJREFUaAW9wbGLlgUAB+Dny19D0KJh0FAabi1yhBBcQdAitQj6L2hDtASCiwQ1KI4ODe5Bf0DEEVzQkLfcEpVidA0aIQQK1iAqXMM7fIp+n/fee/yeJ8qiLMqiLMqiLMqiLEY4h4umibIoi7IY4aLpoizKoiyW+Amr9laURVmUxRKr9l6URVmURVmURVmUxQKncBp/4z6+xm38YZooi7IoiwUu4bC5j/EvfrPcX7iETc8WZVEWZbHAaRzFNbyFFbyPd3ALr5t7hH/wmsFNbHq2KIuyKIvHbGNmsI51gzWD/VjBJo6Zu4/fcR0H8KfFoizKoiweM7PcXfxgsO5JJ7Efv+Abi0VZlEVZ7IFX8RVewBe4Y7Eoi7Ioiz3wCQ7iLm5YLsqiLMpiolWcMziBXy0XZVEWZTHRh3gR69jwtDO4Yi7KoizKYoKXcBwP8DkeetoVT4qyKIuymOAsVrCGq55vG1EWZVEWu/QRzuMevrTcNmaYIcqiLMpiF17BZezDd9iw3MxclEVZlMVI+7CGN7GF88aJsiiLshjpCN42+AxbxomyKIuyGOEQvjc4i2+NF2VRFmUxwhm8YfAjto0XZVEWZbFD7+FT00VZlEVZ7NC7eNlgC//ZnSiLsiiLkX7GB7hjd6IsyqIsdugCLpguyqIsyv4HjP9ExGhQSGUAAAAASUVORK5C\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
@@ -1097,15 +713,9 @@
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " ⋮                                       ⋱  \n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(1.0)\n",
-       " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)  …  Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)\n",
@@ -1117,9 +727,8 @@
        " Gray{Float64}(0.0)  Gray{Float64}(0.0)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 14,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1127,8 +736,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=1\n",
     ")\n",
@@ -1151,7 +760,10 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwBAMAAAA0zul4AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAElBMVEX5+Pl+uuozcbYILFmRx+/////jii5GAAAAAWJLR0QF+G/pxwAAAENJREFUWMPt1UEJADAMBMFYiIVaiIX411QPLRSy3fkv3O8iBJbJD8nW4oeS9EIVP5Q0UTc//MegyzgKh8y8CiVJEsAGBXEIgdrWYGoAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAIAAABJgmMcAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAV1JREFUeAHtwSFuFAAABdERozB7liZViBouUtkrkGrCFZB7EQyiahPOsoZQh1oJLOGTAJ33fP76THYkU5IpyZRkSjIlmZJMyV/g3aczF493B/5lkinJlGRK/gKPdwf+F5IpyZRkSv6A128/cvH0/g0viWRKMiWZkj/g6f0bXirJlGRKMiWZkkxJpiRTkinJlGRKMiWZkkxJpiRTkinJlGRKMiVXONzec3E+Hcn3SaYkU5IpucL5dCTXkUxJpiRTkinJlGRKMiWZkkxJpiRTkinJlGRKMiX5oQ+fv3DxcPOKn5FMSaYkU5Iferh5xa+QTEmmJFOS33a4vedCMiWZkkxJrna4vefifDpycT4duZBMSaYkU5KrnU9HfkYyJZmSTEmmJFOSKcmUZEoyJZmSTEmmJFOSKcmUZEoyJZmSTEmmJFOSKcmUZEoyJZmSTEmmJFOSKcmUZEoyJZmSTH0Dwu0eYIQY7S0AAAAASUVORK5CYII=",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAIAAABJgmMcAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAV1JREFUeAHtwSFuFAAABdERozB7liZViBouUtkrkGrCFZB7EQyiahPOsoZQh1oJLOGTAJ33fP76THYkU5IpyZRkSjIlmZJMyV/g3aczF493B/5lkinJlGRK/gKPdwf+F5IpyZRkSv6A128/cvH0/g0viWRKMiWZkj/g6f0bXirJlGRKMiWZkkxJpiRTkinJlGRKMiWZkkxJpiRTkinJlGRKMiVXONzec3E+Hcn3SaYkU5IpucL5dCTXkUxJpiRTkinJlGRKMiWZkkxJpiRTkinJlGRKMiX5oQ+fv3DxcPOKn5FMSaYkU5Iferh5xa+QTEmmJFOS33a4vedCMiWZkkxJrna4vefifDpycT4duZBMSaYkU5KrnU9HfkYyJZmSTEmmJFOSKcmUZEoyJZmSTEmmJFOSKcmUZEoyJZmSTEmmJFOSKcmUZEoyJZmSTEmmJFOSKcmUZEoyJZmSTH0Dwu0eYIQY7S0AAAAASUVORK5C\">"
+      ],
       "text/plain": [
        "28×28 Array{RGB{Float64},2} with eltype RGB{Float64}:\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
@@ -1164,13 +776,7 @@
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " ⋮                                         ⋱  \n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.032796,0.17167,0.347312)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
@@ -1182,9 +788,8 @@
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)"
       ]
      },
-     "execution_count": 15,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1212,49 +817,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  25%|█████▊                 |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Objective Value: 0.046085, Solve Time: 42.74\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Objective Value: 0.046085, Solve Time: 545.87\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAALHSURBVGje7dq/r0xBFAfwz/LiVx4FiQh5OhIaEREFhY5QKJQaGhWN0EgU/gydSCQanYhQiB9BJRHxM2hQ0L4tJCQU915vdnbm7ja792WyJ9nszNxzZnK/35wzM+fc3jz6BmW+/u8H7Vw/tusn7MOxFaYs5S84F/IQ8hnzE4/PR/9abMPn5UM6fQ7DTuMvfwz7Upv/xf7ZzDEX9Bud8iGd+oK9kKtG2mJiTlIxN6VfPqTdxNIwLuZ8rD9iolxM7vwNy1+wF+I9yidH8SiaR8KmfEinzyGDmJM+T4Y89xM2Ir1YGrvyIZ1+LM1xcghX8BK/cLMe/5SZKPblcEzwrHxIu/FDhrH/iTV1fz0W69+blsm24Bsu4L20z5YPaXfn0lD6OIA9eIvd2IvD2IavWAj0/2AlNtT9a7gonRMoH9LlwSFp/BdUXN7BfpUT/1XF2o94h404hxu1Xbyflg9p97G07bzSPI9t4CSu4wt2YZX0ebZ8SLvjsJFx+It1NuM11uE0brfYlw9pt7k28n6Y46+Pqyr+fuNDxq6zNyx/wd44+bS22sVB3Kvbx/FYPt528oblLzhQtxjnHh+PHav/X+B5i97sTDMxGdgPc9zl+FyLp9iJI3iW0JndDycucwzXjVJxNcXjJRV/Tyzxl8vTzWrAE5OBu8U4Oe2Gi+O4he84gwfStarZfjhxGfLDlMT1/dW4XPfvqvhj2G9F/Vm+dCKSvOOPkofYh884ih8j9Gf74USll6sz5GLrVlU+G06o+Ixt2s5G5UPabR0/lBR/m3C/bl+yxF/DWdv3VM03OeVD2s1+mLqTx3dFOIvtdftRYDMqxxrOWT6kyyPX1kgYE3fgvKVaoowe7ZyWD2l3HOa+q2nGD9XtRdVZJnV3zOVUO33D8hf8z2EuTxr71CucUtXrY722dtMvH9LllfNu4yMl49iXD+nUF/wHg+y5HmmDeFIAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
@@ -1265,13 +840,7 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " ⋮                         ⋱  \n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)        …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
@@ -1283,9 +852,8 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 16,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1293,8 +861,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf\n",
     ")\n",
@@ -1310,7 +878,10 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwBAMAAAA0zul4AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAJ1BMVEXp9v35+Pnr9/3s9/3/7+vx+v7/8Ovx+f7t+P3v+f7/9PH/9vP///9TFX8KAAAAAWJLR0QMgbNRYwAAAVxJREFUWMPVl0EVAjEMRGMBC1jAQi2sBSxgAQtYwALmoCxDJplyZ3KA3Sa/vDdJ2hARh49FzOeI+g1f+uHzAdmReA3PlYz0A+fL8ciypBC55elE0hmBPZcZyILouhNYJVhhnHpPsJf2b1Ta3gbUosZW6amt/G1kG5APpDEixtt6S1dp6JcsQF7csW0bYtM/htxVJiCnePywiO1lVUhPsC9P5HzmDbjlncB86VnlfS+XuREfZG6gqCS6qd8RZBe/zae9wFk0LxBOvUARer2iiZddYQDKdSkGadolZAf2IZ4NI3zzWoG8pAXP0iDCD1wPtnv47YZjmIdEPzDLIIthGoYl3ZDGXBNQ0Wn3O48MKpsT2NsZVrGe/sU58MfgWhpgj4deSOUEMAF5CWFdmm5tsjIBOdFoYYzvOgr7gdzO9c8ZF/9CHCOQ0wxx9suGsfz8HsgmYEqi7loY1W8EPgFw1YaIp86glAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAIAAABJgmMcAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAABOpJREFUeAHtwcFqXVkOhtHPyk/sELgIB/z+r9cGGxFwl50oco2UymCHU+e2qnqy19J//vuD5pacESVW3JIWJY64JS1KHHFLzogSzS1pUWLFLWlRorklLUqsiG2U2EaJbZTckiNRorklK27JGW7JiluyEiVWosQRt2TFLZngljSxjRLbKLGNEn+DW9KiRLMbfooSK25JixItShxxS85wS1qUOBIl2ocbfvrxzlKUaG5JixJNbKPENkpsoxQlVtySFbekRYnmlrQo0aJEc0talGhuyRG3ZMUtORIlVtySFiWaW3KGW9LENkpso8Q2Sm5JixIrUaK5JWe4JS1KNLfkn+SWHIkSzS2ZILZRYhsltlGKEs0tORIlmluy4pa0KNHckhYlmlvy/xYlVtySM8Q2SmyjxDZKbkmLEteKEs0tWYkSzS1ZiRLNLWlRYoJb0tySa0WJ5pY0sY0S2yixjVKUaG5JixJnPLw90x5v72kPb88ceby9Z5pbshIljrglZ0SJJrZRYhsltlFySyY83t7THt6eWfn6+Qvt8vJEe3h75sgD13u8vWfl4e2Z9u3ThRYlmlvSosQRsY0S2yixjVKUmPDw9syRy8sT/5bH23vanW5YeeSen4qf3JIWJY64JU1so8Q2SmyjxP8gSjT/dKFFiSNuSYsSKw9vzyzd8Jd3lh7envnpjaULf/n26cIZbsmK2EaJbZTYRsktWYkSK25JixItSpwRJVbckvbt04WVKHHG3Ycb2uuPd9rD2zMtSjS3ZMUtOSK2UWIbJbZR4jfckpUoMc0tWYkSE+7ev9NeEe3x9p6VKLESJVbckia2UWIbJbZR4iS3pEWJa7klK1HiDLekRYl2pxtapLiWW3KG2EaJbZTYRilKrLglLUo0t6S5JWdEiRYlVtySFiWORIkm4xS35EiUOENso8Q2Smyj5JYccUtWokRzS1qUuFaUuJbshvaa75wRJc5wS1bENkpso8Q2SvwNUaK5JStR4ohb0qLEtO8/3jkjShxxS1qUaFFiRWyjxDZKbKPEL6LEkSjR3JIWJZpbcsQtaVHiWne6ob3mO0fckhYlmlvSosSKW9KixIrYRoltlNhGiV+4JS1KNLfkiFtyLbekRYkjHz/c0C4vT7TX23uaW9KiRIsSzS1pUaK5JS1KnCG2UWIbJbZR4hdR4p8UJZpbsuKWtI9/fGXl6+cvrLglK27JEbfkDLekRYkmtlFiGyW2UeIXbkmLEi1KNLfkWm7JkY/5ypHLyxP/FrekRYkWJVbENkpso8Q2SlHiiFtyJEo0t+Rq379xxrdPF45EieaWtCjR3JIWJc5wS5rYRoltlNhGyS1pUeJabsm1Pv7xlVNu71iJEs0taW7JiltyhlvSokSLEk1so8Q2SmyjxC/ckiNRYsUtWYkSzS2Z8M0+suKWtCgxLUqsuCVNbKPENkpso8RJbsmRKNHckhYl2sPbMytfP3+hXV6eOCNKNLekRYkVt6RFiQliGyW2UWIbJX4jSjS3ZCVKrLglLUo0t+TI5eWJa7klLUo0t2QlSkwT2yixjRLbKPEbbsm1okRzS1qUaA8ce7y9p7klR6JEc0tWokRzS1aiRHNLjkSJJrZRYhsltlGKEituSYsSzS1pbslKlFhxS9rj7T3NLVlxkjPckpUo0dySCVGiuSVNbKPENkpso/4Eb+X0k62YSkIAAAAASUVORK5CYII=",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAIAAABJgmMcAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAABOpJREFUeAHtwcFqXVkOhtHPyk/sELgIB/z+r9cGGxFwl50oco2UymCHU+e2qnqy19J//vuD5pacESVW3JIWJY64JS1KHHFLzogSzS1pUWLFLWlRorklLUqsiG2U2EaJbZTckiNRorklK27JGW7JiluyEiVWosQRt2TFLZngljSxjRLbKLGNEn+DW9KiRLMbfooSK25JixItShxxS85wS1qUOBIl2ocbfvrxzlKUaG5JixJNbKPENkpsoxQlVtySFbekRYnmlrQo0aJEc0talGhuyRG3ZMUtORIlVtySFiWaW3KGW9LENkpso8Q2Sm5JixIrUaK5JWe4JS1KNLfkn+SWHIkSzS2ZILZRYhsltlGKEs0tORIlmluy4pa0KNHckhYlmlvy/xYlVtySM8Q2SmyjxDZKbkmLEteKEs0tWYkSzS1ZiRLNLWlRYoJb0tySa0WJ5pY0sY0S2yixjVKUaG5JixJnPLw90x5v72kPb88ceby9Z5pbshIljrglZ0SJJrZRYhsltlFySyY83t7THt6eWfn6+Qvt8vJEe3h75sgD13u8vWfl4e2Z9u3ThRYlmlvSosQRsY0S2yixjVKUmPDw9syRy8sT/5bH23vanW5YeeSen4qf3JIWJY64JU1so8Q2SmyjxP8gSjT/dKFFiSNuSYsSKw9vzyzd8Jd3lh7envnpjaULf/n26cIZbsmK2EaJbZTYRsktWYkSK25JixItSpwRJVbckvbt04WVKHHG3Ycb2uuPd9rD2zMtSjS3ZMUtOSK2UWIbJbZR4jfckpUoMc0tWYkSE+7ev9NeEe3x9p6VKLESJVbckia2UWIbJbZR4iS3pEWJa7klK1HiDLekRYl2pxtapLiWW3KG2EaJbZTYRilKrLglLUo0t6S5JWdEiRYlVtySFiWORIkm4xS35EiUOENso8Q2Smyj5JYccUtWokRzS1qUuFaUuJbshvaa75wRJc5wS1bENkpso8Q2SvwNUaK5JStR4ohb0qLEtO8/3jkjShxxS1qUaFFiRWyjxDZKbKPEL6LEkSjR3JIWJZpbcsQtaVHiWne6ob3mO0fckhYlmlvSosSKW9KixIrYRoltlNhGiV+4JS1KNLfkiFtyLbekRYkjHz/c0C4vT7TX23uaW9KiRIsSzS1pUaK5JS1KnCG2UWIbJbZR4hdR4p8UJZpbsuKWtI9/fGXl6+cvrLglK27JEbfkDLekRYkmtlFiGyW2UeIXbkmLEi1KNLfkWm7JkY/5ypHLyxP/FrekRYkWJVbENkpso8Q2SlHiiFtyJEo0t+Rq379xxrdPF45EieaWtCjR3JIWJc5wS5rYRoltlNhGyS1pUeJabsm1Pv7xlVNu71iJEs0taW7JiltyhlvSokSLEk1so8Q2SmyjxC/ckiNRYsUtWYkSzS2Z8M0+suKWtCgxLUqsuCVNbKPENkpso8RJbsmRKNHckhYl2sPbMytfP3+hXV6eOCNKNLekRYkVt6RFiQliGyW2UWIbJX4jSjS3ZCVKrLglLUo0t+TI5eWJa7klLUo0t2QlSkwT2yixjRLbKPEbbsm1okRzS1qUaA8ce7y9p7klR6JEc0tWokRzS1aiRHNLjkSJJrZRYhsltlGKEituSYsSzS1pbslKlFhxS9rj7T3NLVlxkjPckpUo0dySCVGiuSVNbKPENkpso/4Eb+X0k62YSkIAAAAASUVORK5C\">"
+      ],
       "text/plain": [
        "28×28 Array{RGB{Float64},2} with eltype RGB{Float64}:\n",
        " RGB{Float64}(0.911923,0.96363,0.991867)   …  RGB{Float64}(0.911923,0.96363,0.991867)\n",
@@ -1323,13 +894,7 @@
        " RGB{Float64}(0.911923,0.96363,0.991867)      RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.911923,0.96363,0.991867)      RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.911923,0.96363,0.991867)   …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " ⋮                                         ⋱  \n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.911923,0.96363,0.991867)      RGB{Float64}(0.974944,0.972996,0.976035)\n",
@@ -1341,9 +906,8 @@
        " RGB{Float64}(0.911923,0.96363,0.991867)      RGB{Float64}(0.974944,0.972996,0.976035)"
       ]
      },
-     "execution_count": 17,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1356,157 +920,24 @@
    "metadata": {},
    "source": [
     "### $L_2$\n",
-    "With solvers that can handle MIQPs (like Gurobi), we can minimize over the $L_2$ norm. This generally takes a bit more time. \n",
+    "HiGHS is unable to solve MIQPs. With a solver that can (like Gurobi) we can minimize over the $L_2$ norm. This generally takes a bit more time. \n",
     "\n",
-    "In this case, the minimum $L_2$ norm perturbation required for the image to be classified as a `9` is `0.705367 = sqrt(0.497542).`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  40%|█████████▎             |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Objective Value: 0.497542, Solve Time: 815.09\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAARHSURBVGje7ZrPixxFFMc/tdO9M7tudjbRBBU9eRL0IB5EhEBOimAgP/Af8ORN9OBR8C/wnxA8iiB6EA8b9xBPgoEkiuBBQUWSTXazyfT29Hj4vrdVMzvZOc20FPOgmanqqq6u963vq/dedQjAiHFJ67pAZXUNUACllQ8e069jbUfAiv0P1maFBUv+AxYpfq7vAji0uo5dtZVru0orbwG71sfbDKc809dA/ipdPIZpwTl0iHS+DjxAODlGBfAvEeeHyZs7D527q/Y/APfsN3+VLnzAsIr4USeVawibLWCfyLua43Y3fXPH3NfCkHG73MoM8x+w8L0OoAc8St5iA9nJM8CdGQ9qEN4Q18D/Yob5DxjSwinEtVT/jkdJ3CNniXP2LPBP2zPMf8AAsnsBOA3sIS66LXSfpko6pLaxY+URj7ezENdC/ipdPIY+4irCrkTYvQN8BPyI9P858Dfw28TbBrvqpK4hrgGXTZY+zZzkyJauAwPkRx4g3/MMwqFA/KyAn5OOK3Y5XwPwJ/ApcIO4v5ZA39rlr9LF+zRrCJsR8mEGduMy8DLC7FXgFeC8XbeB5xHezr87wLMIxz+ADxF+Aa2Be2g/zV+l7cT4GwjDLeCulbeBH+yNdhCHngZeAq4jXD2WHAC3gF/sGTeSAUp7tvtD+au0PVvaRXx5ADyJcPG8SopBlXTuILz3gavAF8BPwAUUk8DxOCN/lbYbW4B45DawtjeqrTwk+p494AmE9VMIuz7wLvCl9RskbQNLv3ROUkxW7CJ+dYmYuX/pgJ+yugr5P+8j/A6A3xH3aqJv+qjNGeY/YOggv/8uii+qKY38rGKIsNlEnOqiffF7a/c28J21a6zuHPHcY7eNGeY/YDFE+EHEz3MyJcJpkNzzXHdj15tWvw1cQ7xt0HoYWt8eii1bmWH+AxZp3mUd2cMG2cNRUg4IiwbZxhHC6aLVfUL0e9aQHS3R+liztsuzp7nI2PlhRfQja8bzo6lvWljbD4AXkf3csXse7z+0X4C/kK/bb2OG+Q84FlsMZjT0c/mA9r6vgPv2f2eivfszfbR/7rLk4ZykAMUI1YyGztcG+aWfWflrjuMH0Zd1e7yHbHX+Km2PhwXxvHCWbAOvAb8Cb6Hc2knSR9gvc21zkVAi/fYQX5xv076VAngBuIn2yyvANyc8vEC+TEB+0DLnPRcpDpFtnDz/m4bfM8C3du9jTsYP4vdV+/a73A/nIgVor3LZRL6N+zcpH98DnrO6axMP6iRtPT4coPhig8jx/FXabq6tQH5m+jYeG76BzpN6xBjfxXOpXYTdHvKTPE96YPWef12o5D/gEYae24b47eghMf/2OhG/W4xz1+N952+BzhOdf/59YiszzH/AIwxTXnkeLXD8O5rrwCV0zu+Sfm+TroUKYZ6eHeav0nZiC8dn2vdOHud5Hu4kOU3MvYJ8Jeer2+X8VbrwAf8D0LghKV4esdsAAAAASUVORK5CYII=",
-      "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
-       " Gray{Float64}(0.00272082)  …  Gray{Float64}(0.00424106)\n",
-       " Gray{Float64}(0.00071994)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.00289914)\n",
-       " Gray{Float64}(0.0241623)      Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0)\n",
-       " Gray{Float64}(3.3605e-5)   …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.00875976)     Gray{Float64}(0.0577916)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0668495)\n",
-       " Gray{Float64}(0.0345795)      Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0307308)   …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0)\n",
-       " ⋮                          ⋱  \n",
-       " Gray{Float64}(0.00392799)     Gray{Float64}(0.0165317)\n",
-       " Gray{Float64}(0.00120835)     Gray{Float64}(0.131568)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0413101)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0405618)\n",
-       " Gray{Float64}(0.0)         …  Gray{Float64}(0.0330876)\n",
-       " Gray{Float64}(0.0195081)      Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.00496392)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)         …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)            Gray{Float64}(0.00827445)\n",
-       " Gray{Float64}(0.00157579)     Gray{Float64}(0.0)"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
+    "In this case, the minimum $L_2$ norm perturbation required for the image to be classified as a `9` is `0.705367 = sqrt(0.497542).`\n",
+    "\n",
+    "```julia\n",
     "d = MIPVerify.find_adversarial_example(\n",
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => false),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=2\n",
     ")\n",
     "print_summary(d)\n",
     "perturbed_sample_image = value.(d[:PerturbedInput])\n",
-    "colorview(Gray, perturbed_sample_image[1, :, :, 1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAMAAADxPgR5AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAilBMVEXy+v75+Pnx+f7s9/3x+v7w+f7v+f7r9/3q9v3u+P7l9P3p9v3l9Pzi8/zu+P3n9f3m9P3t+P3o9v3a7/vj8/zo9f3g8vzh8vz/8/D/6+X/9fL/9fPm9f3/9PH/7+v/8u7/8+//9vP/8e3k9Pz/8Oz/8OvY7vve8fzV7fvZ7/v/9PD/8u//7+r///81RR+xAAAAAWJLR0QtzdpBPQAAA2VJREFUaN7tmtlyFDEMRacDSQiBQNghLGFf///70JnymRKuSQ8U9pvuQ9ztsX2Uallty73ZhJZORyHrb4Vuh45D3J+ETkN3Qn0/+9CWPo5lSd2mgMOBuYODnoWsY2Ag/eC2uRvSkGWPbCe4gHOB2TlocB7i+l7ofsiSOhwHJ8GpuL8I6Sg6GuWD0MPQRhVwOPAy1D9wBtMh/I2H74C9GAdDH4V0Dg3v/6kCjgfqID5sSp3lcYjySWj5B2mwjljA+UD1NJQb5845oB+SDvYs1P9WwDlAJikT/HlIx3HiUhKYdx3SRHbCHzWtGaHhBRwPtDEgBuCBc/8iRKOXoVdNV6E8CO0AZofqg7fiRfw6VMDxQCtc8LpJoQEGvAkxid+GMOJd03WI3zCEesr3Ifp+CFHqgBjE4utjqIDjgTgGD5iSh2ojBmTgT6GrJgf93ASQNpTCMC4HAYxmbB2rgOOBANhs4CRfQkAJ4k5iHMlJTFvqhFOHwwDUiXQsgQR+/4kCzgF6QaULYCYpGxOCwHnTRVMOyBiCgb7ANSYH+X5RVsB5QMUm9LSJyYohJ015AUU9hmEMhuXFl/1y2z9WbQWcCkS+iJ34uwfegAQJfqd0AWYiiIH9vV9IFXAOkEoWN9z0EzsbwEAkkQDgWFwz6S+bAOJALqTty6aU9jC2SfYCDgfuA7jgoXQQAzSDW0eA91CEeoOExnONUV9Dq15awP8C5uSbGxkXxmh3wNEWtAx63JSDvM7DNXUYpTMCNBFcwPFAAzKlEzw7Th8AkMHaJN5ZUj48yYGfl/W3UAHHA63goS4r8oTaZJAv534Dqnz5MvG/h0j+4kgFnAN0s7L8pdh8AteItbYsqDzkJLAUcA4Q4QAcKh+CkTggWfQjRPLgZ+hQH5MW24PqAg4HukDCcfIEvungA6AwrtdAbooYe3cIXcDhQP7wQE0Krem6CSDOYlL2JmG0iSM/DingHKAiEAPPL+O8UOYABGcB2DuMCSEXuy6kCNxAXVAVcC6w/5DHyQoUB/Hgy6R6NpTSj6645oMRgjbAfIhWwHnAHKzdmHCtAwHBaXAYXsD5MCS3y4abfDBRX8C5wN5Z+g86ONwC+CvUJ17zfe7TL663HzsXcDjQTcn2gXYbkzzQvg/Je5kIUmxCe0MKOBz4GzljYSA9W5Y7AAAAAElFTkSuQmCC",
-      "text/plain": [
-       "28×28 Array{RGB{Float64},2} with eltype RGB{Float64}:\n",
-       " RGB{Float64}(0.948272,0.979477,0.995882)  …  RGB{Float64}(0.946653,0.978783,0.995703)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.948272,0.979477,0.995882)\n",
-       " RGB{Float64}(0.930285,0.971707,0.9939)       RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.943404,0.977388,0.995346)     RGB{Float64}(0.901748,0.959091,0.990733)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.894904,0.956012,0.989966)\n",
-       " RGB{Float64}(0.921985,0.968075,0.992983)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.925315,0.969535,0.993351)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " ⋮                                         ⋱  \n",
-       " RGB{Float64}(0.946653,0.978783,0.995703)     RGB{Float64}(0.93687,0.974567,0.994626)\n",
-       " RGB{Float64}(0.948272,0.979477,0.995882)     RGB{Float64}(0.836567,0.928883,0.983228)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.915289,0.965122,0.992241)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.916968,0.965864,0.992427)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.921985,0.968075,0.992983)\n",
-       " RGB{Float64}(0.933584,0.973142,0.994264)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.946653,0.978783,0.995703)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.943404,0.977388,0.995346)\n",
-       " RGB{Float64}(0.948272,0.979477,0.995882)     RGB{Float64}(0.974944,0.972996,0.976035)"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "diff = value.(d[:Perturbation])\n",
-    "view_diff(diff[1, :, :, 1])"
+    "colorview(Gray, perturbed_sample_image[1, :, :, 1])\n",
+    "```"
    ]
   },
   {
@@ -1529,102 +960,276 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
       "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Gurobi Optimizer version 9.0.2 build v9.0.2rc0 (linux64)\n",
-      "Optimize a model with 1263 rows, 1020 columns and 66888 nonzeros\n",
-      "Model fingerprint: 0xdc39e74c\n",
-      "Variable types: 960 continuous, 60 integer (60 binary)\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [2e-05, 8e+02]\n",
-      "  Objective range  [1e+00, 1e+00]\n",
-      "  Bounds range     [5e-01, 4e+02]\n",
-      "  RHS range        [4e-03, 8e+02]\n",
-      "Presolve added 0 rows and 10 columns\n",
-      "Presolve removed 50 rows and 0 columns\n",
-      "Presolve time: 0.07s\n",
-      "Presolved: 1213 rows, 1030 columns, 62933 nonzeros\n",
-      "Variable types: 970 continuous, 60 integer (60 binary)\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
       "\n",
-      "Root relaxation: objective 0.000000e+00, 938 iterations, 0.05 seconds\n",
+      "Solving MIP model with:\n",
+      "   1203 rows\n",
+      "   1020 cols (60 binary, 0 integer, 0 implied int., 960 continuous)\n",
+      "   66828 nonzeros\n",
       "\n",
-      "    Nodes    |    Current Node    |     Objective Bounds      |     Work\n",
-      " Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "     0     0    0.00000    0    2          -    0.00000      -     -    0s\n",
-      "H    0     0                       0.4967121    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     2    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "H   29    31                       0.0710671    0.00000   100%   250    1s\n",
-      "   151    93    0.00448    7   10    0.07107    0.00000   100%   259    5s\n",
-      "   406   136     cutoff   14         0.07107    0.00000   100%   202   10s\n",
-      "H  420   131                       0.0635998    0.00000   100%   200   10s\n",
-      "H  546   154                       0.0539995    0.00000   100%   189   12s\n",
-      "H  567   144                       0.0539995    0.00000   100%   188   12s\n",
-      "   683   160    0.04687    8    4    0.05400    0.00448  91.7%   185   15s\n",
-      "   973   183 infeasible   15         0.05400    0.00600  88.9%   171   20s\n",
-      "  1308   212     cutoff   24         0.05400    0.00940  82.6%   166   25s\n",
-      "  1801   234     cutoff   20         0.05400    0.02198  59.3%   146   30s\n",
-      "* 1816   209              31       0.0502775    0.02198  56.3%   145   31s\n",
-      "  2254   230    0.03211   13   10    0.05028    0.02944  41.4%   132   35s\n",
-      "* 2352   191              31       0.0462748    0.02981  35.6%   129   35s\n",
-      "H 2586   164                       0.0460847    0.03250  29.5%   126   38s\n",
-      "  2679   151    0.04096   25    3    0.04608    0.03325  27.9%   126   42s\n",
-      "  2831   119     cutoff   19         0.04608    0.03599  21.9%   129   46s\n",
-      "  3001    57     cutoff   23         0.04608    0.03950  14.3%   133   50s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     36      1463     0.1s\n",
+      " R       0       0         0   0.00%   0               0.9762283995     100.00%     2171     33    470      1944     1.2s\n",
+      " L       0       0         0   0.00%   0               0.1207006013     100.00%     2957     57    470      2173     9.2s\n",
       "\n",
-      "Cutting planes:\n",
-      "  Cover: 5\n",
-      "  Implied bound: 35\n",
-      "  MIR: 3\n",
-      "  Flow cover: 7\n",
-      "  Inf proof: 6\n",
+      "1.7% inactive integer columns, restarting\n",
+      "Model after restart has 1201 rows, 1019 cols (59 bin., 0 int., 0 impl., 960 cont.), and 66040 nonzeros\n",
       "\n",
-      "Explored 3276 nodes (429716 simplex iterations) in 52.10 seconds\n",
-      "Thread count was 4 (of 4 available processors)\n",
+      "         0       0         0   0.00%   0               0.1207006013     100.00%       28      0      0     32363     9.4s\n",
+      "         0       0         0   0.00%   0               0.1207006013     100.00%       28     25      7     33215     9.5s\n",
+      "        25       0         3   0.01%   0               0.1207006013     100.00%      343     21     30     56164    14.5s\n",
+      "        73       7        26   0.01%   0               0.1207006013     100.00%      442     21    151     79215    19.6s\n",
+      "       112      24        39   0.01%   0               0.1207006013     100.00%      545     25    206    157481    49.4s\n",
+      "       130      26        48   0.02%   0               0.1207006013     100.00%      607     25    268    181462    54.6s\n",
+      "       169      27        66   0.03%   0               0.1207006013     100.00%      665     25    333    205801    59.8s\n",
+      "       243      46        96   0.71%   0               0.1207006013     100.00%      809     29    410    230041    64.8s\n",
+      "       314      68       121   0.88%   0               0.1207006013     100.00%      903     34    483    451096   136.0s\n",
+      "       440     102       164   0.96%   0               0.1207006013     100.00%      909     20    551    473896   141.1s\n",
+      "       556     124       210   1.02%   0               0.1207006013     100.00%      859     24    634    499140   146.2s\n",
+      "       662     158       244   1.12%   0               0.1207006013     100.00%      892     31    683    526871   151.2s\n",
+      "       844     216       305   1.23%   0               0.1207006013     100.00%     1022     24    793    559188   157.4s\n",
       "\n",
-      "Solution count 7: 0.0460847 0.0462748 0.0502775 ... 0.496712\n",
+      "Restarting search from the root node\n",
+      "Model after restart has 1195 rows, 1016 cols (56 bin., 0 int., 0 impl., 960 cont.), and 63676 nonzeros\n",
       "\n",
-      "Optimal solution found (tolerance 1.00e-04)\n",
-      "Best objective 4.608468158892e-02, best bound 4.608468158892e-02, gap 0.0000%\n",
-      " 52.207113 seconds (1.03 M allocations: 36.524 MiB)\n"
+      "       927       0         0   0.00%   0               0.1207006013     100.00%       24      0      0    563551   158.5s\n",
+      "       927       0         0   0.00%   0               0.1207006013     100.00%       24     14     10    564129   158.6s\n",
+      "      1041      32        35   8.05%   0               0.1207006013     100.00%      628     30     49    581479   164.2s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "      1258      93       111   9.97%   0               0.1207006013     100.00%      744     34    168    606167   169.3s\n",
+      "      1531     205       200  10.06%   0               0.1207006013     100.00%      845     20    292    630027   174.4s\n",
+      "      1743     272       269  10.14%   0               0.1207006013     100.00%      934     32    387    662384   180.4s\n",
+      "      1945     339       337  10.17%   0               0.1207006013     100.00%     1028     30    463    692459   186.4s\n",
+      "      2027     351       370  10.19%   0               0.1207006013     100.00%     1067     30    527    723490   191.7s\n",
+      "      2152     401       406  10.23%   0               0.1207006013     100.00%     1228     38    572    752213   198.3s\n",
+      "      2289     443       456  10.26%   0               0.1207006013     100.00%     1320     44    630    779367   203.3s\n",
+      "      2445     483       516  10.27%   0               0.1207006013     100.00%     1400     49    694    803101   208.3s\n",
+      "\n",
+      "Restarting search from the root node\n",
+      "Model after restart has 1195 rows, 1016 cols (56 bin., 0 int., 0 impl., 960 cont.), and 63676 nonzeros\n",
+      "\n",
+      "      2556       0         0   0.00%   0               0.1207006013     100.00%       52      0      0    826221   213.1s\n",
+      "      2556       0         0   0.00%   0               0.1207006013     100.00%       52     17      4    826873   213.2s\n",
+      "      2618      14        13   5.04%   0               0.1207006013     100.00%      539     26     21    847429   218.2s\n",
+      "      2875      98       106  13.04%   0               0.1207006013     100.00%      746     22    135    871799   223.2s\n",
+      "      3010     142       149  14.14%   0               0.1207006013     100.00%      898     30    189    896571   228.3s\n",
+      "      3195     199       218  15.41%   0               0.1207006013     100.00%     1140     26    282    918971   233.4s\n",
+      "      3408     251       295  17.36%   0               0.1207006013     100.00%     1533     29    429    946021   239.2s\n",
+      "      3607     299       371  17.62%   0               0.1207006013     100.00%     1649     37    564    972977   244.4s\n",
+      "      3766     335       430  17.72%   0               0.1207006013     100.00%     2468     39    638    999802   250.5s\n",
+      "      3841     349       462  18.91%   0               0.1207006013     100.00%     2845     33    678     1022k   255.6s\n",
+      "      3940     371       502  19.55%   0               0.1207006013     100.00%     3091     49    726     1043k   260.6s\n",
+      "      4162     417       586  20.03%   0               0.1207006013     100.00%     3253     41    836     1069k   265.6s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "      4322     450       649  25.87%   0               0.1207006013     100.00%     3551     27    923     1094k   271.3s\n",
+      "      4459     477       700  28.72%   0               0.1207006013     100.00%     4440     54   1000     1110k   276.3s\n",
+      "      4628     528       761  29.38%   0               0.1207006013     100.00%     4616     67   1076     1131k   281.6s\n",
+      "      4828     574       838  29.87%   0               0.1207006013     100.00%     4521     47   1182     1152k   286.8s\n",
+      "      4998     617       899  32.86%   0               0.1207006013     100.00%     4732     62   1249     1174k   291.9s\n",
+      "      5130     649       950  35.91%   0               0.1207006013     100.00%     4997     62   1315     1195k   297.2s\n",
+      "      5337     703      1025  37.47%   0               0.1207006013     100.00%     5348     51   1410     1217k   303.0s\n",
+      "      5502     740      1087  38.39%   0               0.1207006013     100.00%     5520     48   1499     1237k   308.0s\n",
+      "      5695     797      1153  39.44%   0               0.1207006013     100.00%     5860     64   1586     1257k   313.0s\n",
+      "      5952     871      1247  41.17%   0               0.1207006013     100.00%     5719     34   1721     1276k   318.4s\n",
+      "      6080     892      1297  41.37%   0               0.1207006013     100.00%     5155     50   1784     1296k   323.4s\n",
+      "      6364     975      1392  41.73%   0               0.1207006013     100.00%     5127     69   1907     1327k   330.2s\n",
+      "      6451     998      1426  41.74%   0               0.1207006013     100.00%     5157     69   1947     1353k   335.4s\n",
+      "      6601    1030      1479  41.86%   0               0.1207006013     100.00%     5170     46   2025     1380k   340.7s\n",
+      "      6677    1051      1507  42.13%   0               0.1207006013     100.00%     5177     50   2055     1408k   345.8s\n",
+      "      6738    1057      1535  42.13%   0               0.1207006013     100.00%     5255     54   2085     1431k   350.9s\n",
+      "      6777    1057      1554  42.13%   0               0.1207006013     100.00%     5299     60   2112     1461k   356.1s\n",
+      "      6915    1090      1605  42.16%   0               0.1207006013     100.00%     5238     42   2171     1484k   361.1s\n",
+      "      7095    1125      1678  42.18%   0               0.1207006013     100.00%     5280     54   2253     1507k   366.2s\n",
+      "      7207    1143      1724  42.18%   0               0.1207006013     100.00%     5289     23   2324     1533k   371.3s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "      7352    1178      1777  42.18%   0               0.1207006013     100.00%     5384     29   2396     1558k   376.3s\n",
+      "      7467    1201      1822  42.21%   0               0.1207006013     100.00%     4597     60   2447     1576k   381.8s\n",
+      "      7606    1227      1876  43.14%   0               0.1207006013     100.00%     4782     70   2520     1598k   386.8s\n",
+      "      7747    1262      1927  43.93%   0               0.1207006013     100.00%     5006     56   2578     1621k   392.0s\n",
+      "      7954    1303      2009  45.17%   0               0.1207006013     100.00%     5143     40   2675     1639k   397.1s\n",
+      "      8135    1351      2072  45.57%   0               0.1207006013     100.00%     5310     45   2750     1659k   402.1s\n",
+      "      8239    1377      2112  45.72%   0               0.1207006013     100.00%     5488     77   2804     1680k   407.2s\n",
+      "      8412    1422      2171  45.75%   0.000200475575  0.1207006013      99.83%     5718     47   2865     1702k   412.2s\n",
+      "      8538    1446      2221  45.89%   0.000200475575  0.1207006013      99.83%     6062     49   2922     1724k   417.9s\n",
+      "      8665    1476      2271  45.89%   0.000200475575  0.1207006013      99.83%     6279     48   2981     1741k   422.9s\n",
+      "      8824    1497      2337  45.92%   0.000200475575  0.1207006013      99.83%     6710     41   3074     1761k   428.7s\n",
+      "      8969    1524      2396  47.19%   0.000200475575  0.1207006013      99.83%     6997     70   3140     1782k   433.7s\n",
+      "      9107    1550      2447  48.49%   0.000211862717  0.1207006013      99.82%     7319     89   3200     1803k   438.7s\n",
+      "      9193    1571      2484  48.49%   0.000211862717  0.1207006013      99.82%     7392     54   3247     1824k   443.9s\n",
+      "      9267    1584      2513  48.50%   0.000211862717  0.1207006013      99.82%     7178     80   3288     1842k   448.9s\n",
+      "      9315    1589      2533  48.52%   0.000211862717  0.1207006013      99.82%     7672     92   3314     1859k   454.2s\n",
+      "      9416    1604      2572  49.32%   0.000211862717  0.1207006013      99.82%     8122    126   3371     1876k   459.2s\n",
+      "      9486    1614      2605  49.76%   0.000211862717  0.1207006013      99.82%     8264     73   3426     1895k   464.3s\n",
+      "      9553    1620      2636  49.81%   0.00259246277   0.1207006013      97.85%     8339     91   3470     1919k   469.4s\n",
+      "      9695    1646      2693  49.82%   0.00259246277   0.1207006013      97.85%     7849     62   3537     1940k   474.4s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      " T    9753     922      2711  53.59%   0.00259246277   0.1106506926      97.66%     7864     62   3555     1945k   475.5s\n",
+      "      9802     934      2734  53.67%   0.00259246277   0.1106506926      97.66%     7613     62   3580     1961k   480.5s\n",
+      "      9888     951      2767  53.77%   0.00259246277   0.1106506926      97.66%     7414     73   3614     1984k   485.6s\n",
+      "      9933     952      2791  53.78%   0.00259246277   0.1106506926      97.66%     7620     52   3642     2001k   490.7s\n",
+      "     10034     974      2830  53.78%   0.00259246277   0.1106506926      97.66%     7539     77   3684     2023k   496.4s\n",
+      "     10145     994      2871  53.80%   0.0031911298    0.1106506926      97.12%     7326     60   3730     2040k   501.4s\n",
+      "     10260    1015      2917  53.81%   0.0031911298    0.1106506926      97.12%     7227     77   3778     2058k   506.5s\n",
+      " T   10275     648      2919  58.89%   0.0031911298    0.1009421341      96.84%     7229     77   3780     2059k   506.7s\n",
+      " T   10280     306      2922  67.04%   0.0031911298    0.0785359347      95.94%     7232     77   3782     2059k   506.7s\n",
+      "     10373     324      2962  68.98%   0.0031911298    0.0785359347      95.94%     7220     98   3825     2080k   511.8s\n",
+      "     10496     348      3012  69.29%   0.0031911298    0.0785359347      95.94%     7316     83   3896     2099k   517.2s\n",
+      "     10547     350      3038  69.65%   0.00392446141   0.0785359347      95.00%     7491     75   3929     2124k   522.2s\n",
+      "     10714     385      3102  70.25%   0.00392446141   0.0785359347      95.00%     7675     39   4011     2149k   527.2s\n",
+      "     10779     404      3125  70.30%   0.00392446141   0.0785359347      95.00%     8495     76   4039     2163k   532.3s\n",
+      "     10854     407      3161  70.36%   0.0044718657    0.0785359347      94.31%     8471     47   4095     2185k   537.3s\n",
+      "     10962     432      3203  70.36%   0.0044718657    0.0785359347      94.31%     8392     63   4151     2205k   542.4s\n",
+      "     11016     438      3227  70.38%   0.0044718657    0.0785359347      94.31%     8420    102   4185     2222k   547.5s\n",
+      "     11076     444      3254  70.38%   0.0044718657    0.0785359347      94.31%     7699     77   4216     2243k   552.6s\n",
+      "     11151     450      3287  70.39%   0.00598983999   0.0785359347      92.37%     7705     71   4262     2267k   559.0s\n",
+      "     11207     460      3311  70.53%   0.00598983999   0.0785359347      92.37%     8162    103   4297     2285k   564.2s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      " T   11224     443      3314  70.56%   0.00598983999   0.0776398122      92.29%     8165    103   4301     2285k   564.4s\n",
+      " T   11236     430      3320  70.64%   0.00598983999   0.076787908       92.20%     8170    103   4306     2286k   564.6s\n",
+      "     11351     455      3368  70.92%   0.00598983999   0.076787908       92.20%     7919     91   4381     2304k   569.8s\n",
+      "     11474     475      3419  71.51%   0.00598983999   0.076787908       92.20%     8302     56   4457     2325k   574.8s\n",
+      "     11558     496      3451  71.54%   0.00598983999   0.076787908       92.20%     8476     65   4493     2343k   579.9s\n",
+      "     11643     514      3482  71.55%   0.00598983999   0.076787908       92.20%     8298     92   4534     2362k   584.9s\n",
+      "     11740     526      3527  71.71%   0.00598983999   0.076787908       92.20%     8464     25   4589     2383k   590.0s\n",
+      "     11863     546      3577  72.83%   0.00598983999   0.076787908       92.20%     8758     38   4663     2406k   595.1s\n",
+      "     11893     548      3593  73.36%   0.00598983999   0.076787908       92.20%     8727    104   4684     2420k   600.1s\n",
+      "     11952     549      3621  73.39%   0.00598983999   0.076787908       92.20%     8700     91   4718     2439k   605.5s\n",
+      "     12043     562      3658  73.53%   0.00598983999   0.076787908       92.20%     8736     91   4774     2460k   610.8s\n",
+      "     12096     568      3678  73.57%   0.00598983999   0.076787908       92.20%     8976     66   4795     2477k   615.9s\n",
+      "     12180     589      3708  73.59%   0.00598983999   0.076787908       92.20%     9194     74   4833     2497k   621.0s\n",
+      "     12245     604      3732  73.64%   0.00598983999   0.076787908       92.20%     8986     92   4863     2514k   626.0s\n",
+      "     12345     625      3770  73.73%   0.00598983999   0.076787908       92.20%     7805     65   4920     2536k   632.4s\n",
+      "     12437     645      3806  73.74%   0.00598983999   0.076787908       92.20%     7841     65   4963     2556k   637.4s\n",
+      "     12543     667      3849  74.41%   0.00598983999   0.076787908       92.20%     7640     76   5024     2576k   642.6s\n",
+      "     12576     664      3867  74.57%   0.00598983999   0.076787908       92.20%     7910    113   4907     2591k   647.7s\n",
+      "     12655     670      3901  74.61%   0.00598983999   0.076787908       92.20%     7570     74   4760     2609k   652.8s\n",
+      "     12748     681      3942  74.94%   0.00598983999   0.076787908       92.20%     7484     80   4718     2627k   657.8s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "     12816     698      3968  74.95%   0.00598983999   0.076787908       92.20%     7682     57   4654     2641k   663.1s\n",
+      "     12885     707      3997  75.03%   0.00598983999   0.076787908       92.20%     8156     71   4572     2660k   668.1s\n",
+      "     13027     734      4056  80.85%   0.00598983999   0.076787908       92.20%     8237     82   4583     2683k   673.2s\n",
+      " T   13041     438      4059  86.15%   0.00598983999   0.0635998471      90.58%     8240     82   4586     2683k   673.4s\n",
+      " T   13054     392      4065  86.25%   0.00598983999   0.0592820117      89.90%     8245     82   4593     2684k   673.6s\n",
+      "     13126     403      4098  86.58%   0.00598983999   0.0592820117      89.90%     7902     32   4546     2703k   679.1s\n",
+      "     13180     400      4126  86.92%   0.00598986619   0.0592820117      89.90%     7658     60   4454     2718k   684.5s\n",
+      " T   13268     390      4158  88.66%   0.00598986619   0.0570215405      89.50%     7595     22   4335     2728k   688.2s\n",
+      " T   13272     389      4160  88.66%   0.00598986619   0.0569527392      89.48%     7597     22   4336     2728k   688.2s\n",
+      " T   13276     338      4162  89.12%   0.00598986619   0.0537550613      88.86%     7598     22   4337     2728k   688.3s\n",
+      " T   13305     285      4173  89.20%   0.00598986619   0.0502852709      88.09%     7572     28   4289     2731k   689.3s\n",
+      " T   13320     221      4180  91.15%   0.00598986619   0.0460846816      87.00%     7579     28   4296     2733k   689.7s\n",
+      "     13380     227      4209  91.18%   0.0102990452    0.0460846816      77.65%     7830     64   4144     2748k   694.7s\n",
+      "     13446     222      4241  91.25%   0.0102990452    0.0460846816      77.65%     7507     56   3976     2764k   699.7s\n",
+      "     13508     217      4273  93.70%   0.0116816257    0.0460846816      74.65%     7369     56   3691     2789k   705.0s\n",
+      "     13585     220      4311  93.70%   0.0136657429    0.0460846816      70.35%     6358     36   3402     2805k   710.3s\n",
+      "     13650     217      4345  93.72%   0.0136657429    0.0460846816      70.35%     5314     50   3181     2823k   715.5s\n",
+      "     13706     214      4374  94.60%   0.013766096     0.0460846816      70.13%     5002     57   2939     2841k   720.6s\n",
+      "     13768     217      4403  94.61%   0.013766096     0.0460846816      70.13%     5317     31   2794     2855k   725.6s\n",
+      "     13820     207      4434  94.66%   0.0155336272    0.0460846816      66.29%     4638     38   2548     2877k   730.9s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "     13879     202      4465  94.84%   0.015877494     0.0460846816      65.55%     5070     49   2341     2893k   736.4s\n",
+      "     13915     190      4489  94.88%   0.0178616536    0.0460846816      61.24%     5231     46   2113     2917k   741.5s\n",
+      "     13956     178      4514  94.91%   0.0186892675    0.0460846816      59.45%     5499     44   2061     2941k   746.5s\n",
+      "     14029     170      4554  95.36%   0.0210823955    0.0460846816      54.25%     5564     24   2012     2960k   751.5s\n",
+      "     14085     165      4586  96.18%   0.0222289664    0.0460846816      51.76%     5230     53   1933     2978k   756.6s\n",
+      "     14124     158      4609  96.23%   0.0232147138    0.0460846816      49.63%     5507     50   1790     2995k   761.8s\n",
+      "     14178     149      4640  97.03%   0.023214715     0.0460846816      49.63%     5776     47   1714     3014k   767.2s\n",
+      "     14241     144      4674  97.89%   0.0232580021    0.0460846816      49.53%     5797     27   1689     3035k   772.5s\n",
+      "     14282     135      4699  97.90%   0.0268318457    0.0460846816      41.78%     6003     47   1664     3055k   777.7s\n",
+      "     14317     124      4719  98.45%   0.027303379     0.0460846816      40.75%     5974     68   1475     3078k   782.7s\n",
+      "     14427     127      4774  98.69%   0.0274429983    0.0460846816      40.45%     5481     35   1443     3096k   787.7s\n",
+      "     14464     110      4801  98.81%   0.0296721541    0.0460846816      35.61%     5438     42   1407     3120k   792.8s\n",
+      "     14512      95      4832  98.89%   0.0299705275    0.0460846816      34.97%     5062     66   1314     3145k   798.7s\n",
+      "     14540      83      4852  98.96%   0.0320819699    0.0460846816      30.38%     5349     48   1209     3165k   804.0s\n",
+      "     14615      75      4894  99.30%   0.0333533213    0.0460846816      27.63%     5311     75   1130     3184k   809.0s\n",
+      "     14645      58      4917  99.43%   0.0342174555    0.0460846816      25.75%     5531     37   1094     3209k   814.5s\n",
+      "     14699      47      4950  99.55%   0.0375726102    0.0460846816      18.47%     5265     39    987     3230k   819.5s\n",
+      "     14779      45      4989  99.57%   0.0377911387    0.0460846816      18.00%     4670     63    892     3245k   824.5s\n",
+      "     14832      32      5023  99.65%   0.0382345969    0.0460846816      17.03%     4616     57    853     3265k   829.5s\n",
+      "     14906      29      5062  99.69%   0.0387795214    0.0460846816      15.85%     4573     60    851     3281k   834.6s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "     14966      24      5092  99.74%   0.0394675701    0.0460846816      14.36%     4758     69    859     3304k   839.6s\n",
+      "     15044       9      5140  99.98%   0.0413783822    0.0460846816      10.21%     5126     43    883     3320k   844.9s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.0460846815889\n",
+      "  Dual bound        0.0460828522316\n",
+      "  Gap               0.00397% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.0460846815889 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    7.77156117238e-16 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            846.96 (total)\n",
+      "                    0.11 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             15055\n",
+      "  LP iterations     3330503 (total)\n",
+      "                    162466 (strong br.)\n",
+      "                    127990 (separation)\n",
+      "                    298572 (heuristics)\n",
+      "847.007279 seconds (1.67 M allocations: 56.719 MiB)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 52.0963\n",
-       "  :TotalTime          => 52.1851\n",
-       "  :Perturbation       => GenericAffExpr{Float64,VariableRef}[noname noname … no…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 846.962\n",
+       "  :TotalTime          => 847.007\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
        "  :TighteningApproach => \"interval_arithmetic\"\n",
        "  :PerturbationFamily => unrestricted\n",
        "  :SolveStatus        => OPTIMAL\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[-0.012063867412507…\n",
+       "  :Output             => AffExpr[-0.012063867412507534 _[865] + 0.6606525778770…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 27,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1632,8 +1237,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => true),\n",
     "    tightening_algorithm = interval_arithmetic,\n",
     "    norm_order=Inf\n",
     ")"
@@ -1648,129 +1253,193 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  35%|████████               |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Gurobi Optimizer version 9.0.2 build v9.0.2rc0 (linux64)\n",
-      "Optimize a model with 1263 rows, 1020 columns and 66888 nonzeros\n",
-      "Model fingerprint: 0x0202e6a7\n",
-      "Variable types: 960 continuous, 60 integer (60 binary)\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [2e-05, 7e+02]\n",
-      "  Objective range  [1e+00, 1e+00]\n",
-      "  Bounds range     [5e-01, 3e+02]\n",
-      "  RHS range        [4e-03, 7e+02]\n",
-      "Presolve added 0 rows and 10 columns\n",
-      "Presolve removed 50 rows and 0 columns\n",
-      "Presolve time: 0.09s\n",
-      "Presolved: 1213 rows, 1030 columns, 62933 nonzeros\n",
-      "Variable types: 970 continuous, 60 integer (60 binary)\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
       "\n",
-      "Root relaxation: objective 0.000000e+00, 837 iterations, 0.08 seconds\n",
+      "Solving MIP model with:\n",
+      "   1203 rows\n",
+      "   1020 cols (60 binary, 0 integer, 0 implied int., 960 continuous)\n",
+      "   66828 nonzeros\n",
       "\n",
-      "    Nodes    |    Current Node    |     Objective Bounds      |     Work\n",
-      " Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "     0     0    0.00000    0    1          -    0.00000      -     -    0s\n",
-      "H    0     0                       0.4967121    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     2    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "H   29    31                       0.3535137    0.00000   100%   429    2s\n",
-      "    67    89    0.01071   20   16    0.35351    0.00000   100%   423    5s\n",
-      "H   95   102                       0.2051025    0.00000   100%   369    5s\n",
-      "*  145   139              42       0.2051025    0.00000   100%   320    6s\n",
-      "   254   233    0.15085   15    8    0.20510    0.00000   100%   273   10s\n",
-      "H  315   227                       0.1476387    0.00000   100%   241   11s\n",
-      "H  360   216                       0.1309385    0.00000   100%   226   12s\n",
-      "   496   245 infeasible   30         0.13094    0.00000   100%   196   15s\n",
-      "*  736   285              40       0.1084155    0.00000   100%   178   19s\n",
-      "H  764   249                       0.0958362    0.00000   100%   178   21s\n",
-      "H  810   268                       0.0696157    0.00000   100%   176   24s\n",
-      "   816   270    0.02997   25    5    0.06962    0.00000   100%   177   25s\n",
-      "*  892   259              42       0.0574457    0.00447  92.2%   172   27s\n",
-      "*  893   246              42       0.0574449    0.00447  92.2%   172   27s\n",
-      "   985   240    0.03383   24    2    0.05744    0.00808  85.9%   168   30s\n",
-      "* 1148   201              41       0.0564840    0.02084  63.1%   156   32s\n",
-      "* 1149   191              41       0.0537551    0.02084  61.2%   156   32s\n",
-      "* 1252   168              40       0.0502853    0.02545  49.4%   149   34s\n",
-      "* 1255   145              40       0.0460847    0.02545  44.8%   149   34s\n",
-      "  1334   124    0.03878   25   10    0.04608    0.02679  41.9%   144   35s\n",
-      "  1734   111     cutoff   26         0.04608    0.03239  29.7%   127   40s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     36      1504     0.1s\n",
+      " R       0       0         0   0.00%   0               0.2260962872     100.00%     2331     37    517      1954     1.2s\n",
+      " L       0       0         0   0.00%   0               0.1207006013     100.00%     2331     37    517      1954    17.7s\n",
+      "        30       3         5   0.00%   0               0.1207006013     100.00%     2351     25    540     91672    22.7s\n",
+      "        47       6        13   0.00%   0               0.1207006013     100.00%     2371     25    569    121937    28.8s\n",
+      "        75       8        27   0.03%   0               0.1207006013     100.00%     2408     25    624    145223    33.9s\n",
+      "       150      30        51   3.21%   0               0.1207006013     100.00%     2595     28    698    169067    39.1s\n",
+      "       279      62       105   3.66%   0               0.1207006013     100.00%     2794     24    857    190646    44.1s\n",
+      "       380      83       144   5.26%   0               0.1207006013     100.00%     2965     28    936    216571    49.1s\n",
+      "       511     113       198   7.34%   0               0.1207006013     100.00%     3497     36   1029    246199    55.3s\n",
+      "       641     133       251   8.14%   0               0.1207006013     100.00%     3587     42   1117    269990    60.3s\n",
+      "       801     162       318   8.92%   0               0.1207006013     100.00%     4411     60   1208    292809    65.4s\n",
+      "       892     179       354   9.20%   0               0.1207006013     100.00%     4501     67   1273    316203    70.4s\n",
+      "       975     187       392   9.59%   0               0.1207006013     100.00%     4962     68   1344    339590    75.6s\n",
+      "      1121     194       461  11.14%   0               0.1207006013     100.00%     5127     59   1487    365961    80.9s\n",
+      "      1392     252       566  11.93%   0               0.1207006013     100.00%     5104     70   1640    389203    86.0s\n",
+      "      1631     306       659  12.06%   0               0.1207006013     100.00%     4712     33   1787    420206    92.0s\n",
+      "      1866     340       758  12.11%   0               0.1207006013     100.00%     4470     41   1908    445735    97.0s\n",
+      "      1982     353       810  12.17%   0               0.1207006013     100.00%     4868     73   1986    467685   102.1s\n",
       "\n",
-      "Cutting planes:\n",
-      "  Gomory: 5\n",
-      "  Projected implied bound: 3\n",
-      "  MIR: 1\n",
-      "  Flow cover: 3\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "Explored 2020 nodes (244073 simplex iterations) in 42.99 seconds\n",
-      "Thread count was 4 (of 4 available processors)\n",
+      "      2046     354       843  17.26%   0               0.1207006013     100.00%     5341     91   2051    484751   107.1s\n",
+      "      2099     354       869  18.39%   0               0.1207006013     100.00%     5371     91   2110    506422   112.1s\n",
+      "      2223     367       922  18.45%   0               0.1207006013     100.00%     5005     35   2195    529729   117.1s\n",
+      "      2421     412       998  18.47%   0               0.1207006013     100.00%     4698     45   2297    560674   122.7s\n",
+      "      2618     440      1084  18.48%   0               0.1207006013     100.00%     4629     55   2418    589772   130.1s\n",
+      "      2754     470      1136  18.48%   0               0.1207006013     100.00%     4479     36   2495    613498   135.8s\n",
+      "      2863     485      1182  19.00%   0               0.1207006013     100.00%     4880     65   2557    634866   140.8s\n",
+      "      3019     518      1244  21.15%   0               0.1207006013     100.00%     5261     59   2678    657805   146.6s\n",
+      "      3222     540      1334  21.16%   0               0.1207006013     100.00%     4204     52   2848    684903   153.1s\n",
+      "      3420     561      1424  21.16%   0               0.1207006013     100.00%     4337     62   2996    710144   158.2s\n",
+      "      3618     586      1509  21.16%   0               0.1207006013     100.00%     4370     54   3102    732712   163.2s\n",
+      "      3776     601      1578  21.17%   0               0.1207006013     100.00%     4457     50   3209    751994   168.2s\n",
+      " T    3899     142      1628  28.11%   0               0.0942444257     100.00%     4480     54   3270    765037   171.2s\n",
+      " T    3908     141      1632  28.11%   0               0.0936965516     100.00%     4484     54   3273    765423   171.3s\n",
+      "      4082     167      1707  32.59%   0               0.0936965516     100.00%     4742     31   3427    789962   176.4s\n",
+      "      4318     200      1810  33.07%   0               0.0936965516     100.00%     4912     44   3622    814536   181.4s\n",
+      "      4432     210      1863  33.20%   0               0.0936965516     100.00%     5150    101   3711    845771   189.5s\n",
+      "      4534     212      1912  33.54%   0               0.0936965516     100.00%     5051    111   3823    871244   194.5s\n",
+      "      4616     215      1951  33.97%   0               0.0936965516     100.00%     5088    111   3937    891790   199.6s\n",
+      "      4746     222      2012  35.49%   0               0.0936965516     100.00%     5479     53   4119    911313   204.7s\n",
       "\n",
-      "Solution count 10: 0.0460847 0.0502853 0.0537551 ... 0.130938\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "Optimal solution found (tolerance 1.00e-04)\n",
-      "Best objective 4.608468158892e-02, best bound 4.608468158892e-02, gap 0.0000%\n",
-      " 43.813121 seconds (2.18 M allocations: 73.722 MiB)\n"
+      "      4833     228      2054  35.88%   0               0.0936965516     100.00%     6096     77   4242    928367   210.0s\n",
+      "      5037     259      2140  35.88%   0               0.0936965516     100.00%     6284     93   4395    948731   215.0s\n",
+      "      5054     254      2150  36.43%   0               0.0936965516     100.00%     6254    140   4417    961433   220.3s\n",
+      "      5142     257      2192  37.45%   0               0.0936965516     100.00%     6296    140   4500    980546   225.3s\n",
+      "      5221     260      2231  37.65%   0               0.0936965516     100.00%     6518    149   4574     1000k   230.6s\n",
+      "      5263     258      2253  37.72%   0               0.0936965516     100.00%     6806     98   4625     1017k   235.6s\n",
+      "      5476     299      2339  44.70%   0               0.0936965516     100.00%     6995     66   4770     1034k   240.7s\n",
+      "      5580     312      2384  46.24%   0               0.0936965516     100.00%     9323    100   4897     1047k   246.6s\n",
+      "      5636     309      2413  48.01%   0               0.0936965516     100.00%     9703     83   4943     1063k   252.4s\n",
+      "      5745     318      2462  51.03%   0               0.0936965516     100.00%     9998     94   5059     1083k   257.4s\n",
+      "      5980     373      2549  52.08%   4.39241073e-05  0.0936965516      99.95%    10038    111   5191     1098k   262.5s\n",
+      "      6151     407      2621  52.17%   4.39241073e-05  0.0936965516      99.95%     9723     42   5300     1115k   267.6s\n",
+      " T    6325     424      2681  52.28%   4.39241073e-05  0.0933310059      99.95%    10026     46   5371     1132k   271.6s\n",
+      " L    6340      94      2687  68.08%   4.39241073e-05  0.0592820117      99.93%     9899     50   5378     1133k   292.7s\n",
+      "      6464     108      2741  68.08%   4.39241073e-05  0.0592820117      99.93%     9763     81   5452     1239k   299.4s\n",
+      "      6512     109      2761  68.44%   4.39241073e-05  0.0592820117      99.93%     9547     68   5476     1259k   304.5s\n",
+      "      6632     131      2813  68.46%   4.39241073e-05  0.0592820117      99.93%     9498     68   5547     1276k   309.8s\n",
+      "      6787     150      2879  68.52%   4.39241073e-05  0.0592820117      99.93%     9303     73   5648     1295k   314.8s\n",
+      "      6885     167      2918  68.62%   0.000211862717  0.0592820117      99.64%     9435     59   5699     1311k   319.9s\n",
+      " T    6892     159      2920  68.72%   0.000211862717  0.0584730533      99.64%     9437     59   5701     1311k   319.9s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "      6943     160      2949  70.35%   0.000211862717  0.0584730533      99.64%     9995     87   5736     1331k   325.7s\n",
+      "      7148     195      3032  71.29%   0.00406013893   0.0584730533      93.06%     9603     45   5864     1350k   331.2s\n",
+      "      7321     228      3102  71.40%   0.00406013893   0.0584730533      93.06%     9854     55   5978     1370k   336.2s\n",
+      "      7407     232      3143  71.46%   0.00406013893   0.0584730533      93.06%    10953     75   6050     1388k   341.9s\n",
+      "      7528     254      3192  71.53%   0.00406013893   0.0584730533      93.06%     9751     85   6111     1407k   347.2s\n",
+      "      7639     278      3237  72.31%   0.00406013893   0.0584730533      93.06%    10369     74   6174     1425k   352.2s\n",
+      "      7688     280      3261  72.74%   0.00436601528   0.0584730533      92.53%    10859     82   6218     1436k   357.4s\n",
+      "      7852     297      3333  72.78%   0.00436601528   0.0584730533      92.53%    10148     98   6350     1456k   362.4s\n",
+      "      7969     308      3386  72.98%   0.00436601528   0.0584730533      92.53%     9936    117   6429     1470k   367.8s\n",
+      "      8040     307      3422  75.13%   0.0044718657    0.0584730533      92.35%     9841     59   6485     1488k   372.9s\n",
+      "      8183     326      3482  76.48%   0.0044718657    0.0584730533      92.35%     9309     60   6568     1502k   377.9s\n",
+      "      8339     342      3553  76.50%   0.0044718657    0.0584730533      92.35%     9803     74   6699     1523k   383.0s\n",
+      "      8458     359      3603  77.92%   0.0044718657    0.0584730533      92.35%     9066     42   6759     1543k   388.0s\n",
+      "      8569     365      3655  78.44%   0.0044718657    0.0584730533      92.35%     9965     68   6831     1562k   393.1s\n",
+      "      8758     379      3742  79.19%   0.0044718657    0.0584730533      92.35%    10122     35   6958     1579k   398.1s\n",
+      "      8888     390      3802  79.26%   0.0044718657    0.0584730533      92.35%     9238     52   7047     1597k   403.1s\n",
+      "      9006     390      3861  79.79%   0.0044718657    0.0584730533      92.35%     9849     59   7122     1616k   408.2s\n",
+      "      9060     386      3890  80.07%   0.00598983999   0.0584730533      89.76%     9735     50   7157     1631k   413.3s\n",
+      "      9165     386      3941  80.95%   0.00598983999   0.0584730533      89.76%     9992     63   7239     1649k   418.3s\n",
+      "      9310     406      4005  82.05%   0.00598983999   0.0584730533      89.76%    10489     76   7357     1667k   423.7s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "      9495     429      4085  82.10%   0.00598983999   0.0584730533      89.76%     9488     42   7516     1686k   428.8s\n",
+      "      9662     455      4153  82.12%   0.00598983999   0.0584730533      89.76%     9765     51   7620     1703k   433.9s\n",
+      "      9724     462      4183  82.13%   0.00598983999   0.0584730533      89.76%     9129     90   7666     1712k   439.4s\n",
+      "      9861     475      4244  82.14%   0.00598983999   0.0584730533      89.76%    10095     78   7755     1729k   444.4s\n",
+      "      9982     492      4298  82.15%   0.00599172376   0.0584730533      89.75%     7654     83   7836     1748k   449.5s\n",
+      "     10104     513      4346  82.15%   0.00599172376   0.0584730533      89.75%     8425     94   7898     1766k   454.6s\n",
+      "\n",
+      "Restarting search from the root node\n",
+      "Model after restart has 1152 rows, 990 cols (39 bin., 0 int., 0 impl., 951 cont.), and 42855 nonzeros\n",
+      "\n",
+      "     10182       0         0   0.00%   0.00599172376   0.0584730533      89.75%       90      0      0     1780k   458.6s\n",
+      "     10182       0         0   0.00%   0.00599172376   0.0584730533      89.75%       90      9      9     1781k   458.8s\n",
+      "     10403      31        91  53.29%   0.00599172376   0.0584730533      89.75%     1224     26    154     1802k   463.8s\n",
+      "     10587      57       168  70.08%   0.00599172376   0.0584730533      89.75%     3366     53    283     1830k   470.2s\n",
+      "     10836      95       262  74.17%   0.0070120559    0.0584730533      88.01%     4494     46    412     1850k   475.5s\n",
+      "     10965     112       317  80.94%   0.0070120559    0.0584730533      88.01%     5549     55    493     1867k   481.8s\n",
+      "     11139     145       385  82.52%   0.0146594215    0.0584730533      74.93%     4710     50    604     1885k   487.7s\n",
+      "     11325     178       459  85.03%   0.0176698194    0.0584730533      69.78%     4895     51    695     1903k   492.8s\n",
+      "     11516     220       535  85.17%   0.0223330481    0.0584730533      61.81%     5411     48    792     1916k   497.8s\n",
+      "     11638     222       589  86.93%   0.0224681328    0.0584730533      61.58%     5291     33    854     1931k   503.0s\n",
+      " T   11676     174       606  88.29%   0.0224681328    0.0554554748      59.48%     5431     35    871     1937k   504.9s\n",
+      " T   11687     118       612  93.91%   0.0224681328    0.0498354344      54.92%     5437     35    877     1937k   505.0s\n",
+      " T   11730      97       633  94.22%   0.0224681328    0.0460846816      51.25%     5457     35    897     1939k   505.7s\n",
+      "     11835     103       682  95.19%   0.0317301163    0.0460846816      31.15%     6578     55    981     1952k   510.8s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "     11926      94       732  95.41%   0.0354774217    0.0460846816      23.02%     6661     26   1043     1966k   515.9s\n",
+      "     11987      75       773  95.63%   0.0365260193    0.0460846816      20.74%     5865     27   1094     1978k   521.2s\n",
+      "     12090      67       822  96.13%   0.037204082     0.0460846816      19.27%     5267     49   1164     1990k   526.8s\n",
+      "     12154      51       862  97.74%   0.0389159787    0.0460846816      15.56%     4599     46   1206     2004k   532.0s\n",
+      "     12198      37       891  97.95%   0.0399985534    0.0460846816      13.21%     5138     40   1243     2015k   537.1s\n",
+      "     12261      25       928  99.16%   0.0416131647    0.0460846816       9.70%     5358     45   1294     2023k   542.2s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.0460846815889\n",
+      "  Dual bound        0.0460828522316\n",
+      "  Gap               0.00397% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.0460846815889 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    0 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            546.32 (total)\n",
+      "                    0.11 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             12314\n",
+      "  LP iterations     2037617 (total)\n",
+      "                    139358 (strong br.)\n",
+      "                    70276 (separation)\n",
+      "                    149604 (heuristics)\n",
+      "546.723810 seconds (1.90 M allocations: 72.456 MiB)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 42.9934\n",
-       "  :TotalTime          => 43.6904\n",
-       "  :Perturbation       => GenericAffExpr{Float64,VariableRef}[noname noname … no…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 546.327\n",
+       "  :TotalTime          => 546.724\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
        "  :TighteningApproach => \"lp\"\n",
        "  :PerturbationFamily => unrestricted\n",
        "  :SolveStatus        => OPTIMAL\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[-0.012063867412507…\n",
+       "  :Output             => AffExpr[-0.012063867412507534 _[865] + 0.6606525778770…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 21,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1778,8 +1447,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => true),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf\n",
     ")"
@@ -1787,141 +1456,177 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  10%|██▎                    |  ETA: 0:00:42\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:02:17\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:02:35\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Gurobi Optimizer version 9.0.2 build v9.0.2rc0 (linux64)\n",
-      "Optimize a model with 1263 rows, 1020 columns and 66888 nonzeros\n",
-      "Model fingerprint: 0x04b67a3b\n",
-      "Variable types: 960 continuous, 60 integer (60 binary)\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [2e-05, 7e+02]\n",
-      "  Objective range  [1e+00, 1e+00]\n",
-      "  Bounds range     [5e-01, 4e+02]\n",
-      "  RHS range        [4e-03, 7e+02]\n",
-      "Presolve added 0 rows and 10 columns\n",
-      "Presolve removed 50 rows and 0 columns\n",
-      "Presolve time: 0.06s\n",
-      "Presolved: 1213 rows, 1030 columns, 62933 nonzeros\n",
-      "Variable types: 970 continuous, 60 integer (60 binary)\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
       "\n",
-      "Root relaxation: objective 0.000000e+00, 792 iterations, 0.04 seconds\n",
+      "Solving MIP model with:\n",
+      "   1203 rows\n",
+      "   1020 cols (60 binary, 0 integer, 0 implied int., 960 continuous)\n",
+      "   66828 nonzeros\n",
       "\n",
-      "    Nodes    |    Current Node    |     Objective Bounds      |     Work\n",
-      " Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "     0     0    0.00000    0    4          -    0.00000      -     -    0s\n",
-      "H    0     0                       0.5984254    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    6    0.59843    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    8    0.59843    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    8    0.59843    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    6    0.59843    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    6    0.59843    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    3    0.59843    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.59843    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.59843    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.59843    0.00000   100%     -    0s\n",
-      "     0     2    0.00000    0    2    0.59843    0.00000   100%     -    0s\n",
-      "H   29    31                       0.3535137    0.00000   100%   315    1s\n",
-      "H   43    47                       0.0976870    0.00000   100%   352    2s\n",
-      "   140   106    0.00078   13   10    0.09769    0.00000   100%   289    5s\n",
-      "H  226   109                       0.0719725    0.00000   100%   234    6s\n",
-      "*  265   107              30       0.0712215    0.00000   100%   235    7s\n",
-      "H  336   119                       0.0613848    0.00000   100%   227    9s\n",
-      "   361   119    0.03817   23    5    0.06138    0.00000   100%   221   10s\n",
-      "H  392   118                       0.0584827    0.00000   100%   220   10s\n",
-      "*  396   118              30       0.0584544    0.00000   100%   221   10s\n",
-      "   546   144    0.03002    8    6    0.05845    0.00000   100%   226   15s\n",
-      "   753   183     cutoff   17         0.05845    0.01146  80.4%   210   20s\n",
-      "   928   239     cutoff   14         0.05845    0.02208  62.2%   208   26s\n",
-      "  1138   266    0.03425   14    4    0.05845    0.02460  57.9%   203   30s\n",
-      "* 1194   265              26       0.0565325    0.02491  55.9%   205   31s\n",
-      "H 1318   197                       0.0498354    0.02712  45.6%   203   34s\n",
-      "  1367   203    0.02847   15    5    0.04984    0.02838  43.1%   202   35s\n",
-      "* 1431   181              24       0.0460847    0.02863  37.9%   203   36s\n",
-      "  1651   190 infeasible   25         0.04608    0.03074  33.3%   201   41s\n",
-      "  1868   170    0.04118   29    2    0.04608    0.03473  24.6%   203   46s\n",
-      "  2170   130    0.04593   22    2    0.04608    0.03748  18.7%   198   51s\n",
-      "  2370    63    0.04523   12    4    0.04608    0.03884  15.7%   198   56s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     36      1529     0.1s\n",
+      " R       0       0         0   0.00%   0               0.5055138665     100.00%     1571     26     61      1999     0.8s\n",
+      " L       0       0         0   0.00%   0               0.1263064504     100.00%     2642     56    541      2281    10.0s\n",
+      "        27       4         5   0.78%   0               0.1263064504     100.00%     2659     27    576     94655    19.3s\n",
+      "        32       6         8   0.80%   0               0.1263064504     100.00%     2673     27    590    125764    25.6s\n",
+      "        71       6        27   0.87%   0               0.1263064504     100.00%     2700     27    632    150407    31.0s\n",
+      "       111      23        42   1.04%   0               0.1263064504     100.00%     2767     31    658    218206    73.1s\n",
+      "       289      53       112   1.18%   0               0.1263064504     100.00%     2934     37    805    243133    78.3s\n",
+      "       333      71       130   2.05%   0               0.1263064504     100.00%     4347     72    841    254737    83.3s\n",
+      "       475     102       183  25.22%   0               0.1263064504     100.00%     4295     81    923    297104    93.0s\n",
+      "       605     125       235  25.43%   0               0.1263064504     100.00%     4284     50   1014    314179    98.0s\n",
+      "       680     130       269  25.52%   0               0.1263064504     100.00%     4499     64   1060    324104   103.0s\n",
+      "       769     133       313  26.07%   0               0.1263064504     100.00%     4200     73   1141    341366   108.1s\n",
+      "       987     175       400  27.11%   0               0.1263064504     100.00%     4401     44   1297    364500   113.2s\n",
+      "      1131     194       461  28.39%   0               0.1263064504     100.00%     4493     49   1458    388798   118.3s\n",
+      "      1299     237       519  28.66%   0               0.1263064504     100.00%     4631     60   1550    412797   123.3s\n",
+      "      1475     290       584  29.08%   0               0.1263064504     100.00%     4701     42   1639    435131   128.8s\n",
+      "      1675     347       655  29.42%   0               0.1263064504     100.00%     4905     57   1767    458317   134.0s\n",
+      "      1816     380       706  29.86%   0               0.1263064504     100.00%     4984     40   1846    478946   139.0s\n",
       "\n",
-      "Cutting planes:\n",
-      "  Cover: 3\n",
-      "  Implied bound: 15\n",
-      "  MIR: 7\n",
-      "  Flow cover: 15\n",
-      "  Inf proof: 1\n",
-      "  RLT: 7\n",
-      "  Relax-and-lift: 1\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "Explored 2616 nodes (505401 simplex iterations) in 59.17 seconds\n",
-      "Thread count was 4 (of 4 available processors)\n",
+      "      2020     434       779  29.92%   0               0.1263064504     100.00%     5017     53   1965    502224   144.1s\n",
       "\n",
-      "Solution count 10: 0.0460847 0.0498354 0.0565325 ... 0.353514\n",
+      "Restarting search from the root node\n",
+      "Model after restart has 1183 rows, 1008 cols (52 bin., 0 int., 0 impl., 956 cont.), and 57224 nonzeros\n",
       "\n",
-      "Optimal solution found (tolerance 1.00e-04)\n",
-      "Best objective 4.608468158892e-02, best bound 4.608468158892e-02, gap 0.0000%\n",
-      "359.844930 seconds (1.54 M allocations: 53.731 MiB)\n"
+      "      2067       0         0   0.00%   0               0.1263064504     100.00%       53      0      0    503816   144.6s\n",
+      "      2067       0         0   0.00%   0               0.1263064504     100.00%       53     19     10    504795   144.7s\n",
+      "      2274      45        78   5.13%   0               0.1263064504     100.00%     2622     65    157    524177   151.2s\n",
+      "      2475     107       147  21.15%   0               0.1263064504     100.00%     4593     73    240    540305   157.2s\n",
+      "      2883     192       303  23.88%   0               0.1263064504     100.00%     5074     91    425    561309   162.6s\n",
+      "      3148     246       407  23.88%   0               0.1263064504     100.00%     5147     41    576    589631   167.6s\n",
+      "      3360     297       488  23.88%   0               0.1263064504     100.00%     5931     77    709    605003   172.6s\n",
+      "      3630     366       585  24.05%   0               0.1263064504     100.00%     6700     86    902    624299   177.7s\n",
+      "      3902     433       691  33.71%   0.000211862717  0.1263064504      99.83%     7954    106   1049    643033   182.9s\n",
+      "      4185     504       792  36.07%   0.000211862717  0.1263064504      99.83%     8519     63   1213    659393   188.0s\n",
+      "      4398     536       882  36.13%   0.000211862717  0.1263064504      99.83%     8563     70   1337    677955   193.0s\n",
+      "      4572     559       955  36.13%   0.000211862717  0.1263064504      99.83%     8579     52   1434    700075   198.0s\n",
+      "      4789     604      1042  36.29%   0.00344401548   0.1263064504      97.27%     9256     77   1604    719635   203.1s\n",
+      "      5038     655      1137  36.29%   0.00344401548   0.1263064504      97.27%     9755     91   1715    740368   208.1s\n",
+      "      5215     696      1205  36.29%   0.00344401548   0.1263064504      97.27%     9707     74   1786    757310   213.1s\n",
+      " T    5388     674      1275  36.41%   0.00344401548   0.1257451692      97.26%    10036     81   1918    767123   215.8s\n",
+      "      5637     734      1376  36.48%   0.00344401548   0.1257451692      97.26%     9606     69   2101    786571   220.9s\n",
+      "\n",
+      "Restarting search from the root node\n",
+      "Model after restart has 1183 rows, 1008 cols (52 bin., 0 int., 0 impl., 956 cont.), and 57224 nonzeros\n",
+      "\n",
+      "      5807       0         0   0.00%   0.00344401548   0.1257451692      97.26%       70      0      0    802547   224.7s\n",
+      "      5807       0         0   0.00%   0.00344401548   0.1257451692      97.26%       70     23      4    802949   224.7s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "      5943      27        53   1.52%   0.00344401548   0.1257451692      97.26%     5103     94    114    815132   229.7s\n",
+      "      6113      65       121   8.37%   0.00344401548   0.1257451692      97.26%     7480     83    198    826891   234.8s\n",
+      "      6220      92       159  16.44%   0.00344401548   0.1257451692      97.26%     9625     75    239    840856   240.2s\n",
+      "      6455     134       254  21.11%   0.00344401548   0.1257451692      97.26%     9168     61    352    858283   245.2s\n",
+      "      6628     183       318  26.69%   0.0050858007    0.1257451692      95.96%    10044     77    419    874537   250.7s\n",
+      "      6826     210       405  27.71%   0.00915599642   0.1257451692      92.72%    10127    122    543    892977   257.4s\n",
+      "      6899     219       435  33.16%   0.0102639993    0.1257451692      91.84%     9905    104    587    907336   262.5s\n",
+      "      7091     255       515  33.42%   0.013059906     0.1257451692      89.61%    10048    107    683    925110   267.5s\n",
+      "      7307     302       597  33.43%   0.013059906     0.1257451692      89.61%     9111     67    779    941716   272.8s\n",
+      "      7438     326       650  34.23%   0.013059906     0.1257451692      89.61%     9971     81    873    956774   277.9s\n",
+      "      7613     370       716  34.74%   0.0152686057    0.1257451692      87.86%     9900     71    959    971775   283.0s\n",
+      "      7744     393       769  34.80%   0.0152686057    0.1257451692      87.86%     9621     94   1019    987959   288.1s\n",
+      "      8052     466       886  34.83%   0.0152686057    0.1257451692      87.86%     9551     63   1167     1001k   293.4s\n",
+      "      8249     510       961  34.84%   0.0152686057    0.1257451692      87.86%     9888     69   1282     1014k   298.5s\n",
+      " T    8426     520      1029  34.90%   0.0152686057    0.1253687397      87.82%     9701     77   1362     1023k   301.5s\n",
+      " T    8429     362      1031  35.34%   0.0152686057    0.1190512883      87.17%     9704     77   1364     1023k   301.6s\n",
+      "      8502     389      1060  35.49%   0.0152686057    0.1190512883      87.17%     9602    130   1398     1033k   306.7s\n",
+      "      8604     401      1105  35.63%   0.0202044379    0.1190512883      83.03%    10137    162   1454     1048k   311.7s\n",
+      "      8803     445      1183  35.63%   0.0202044379    0.1190512883      83.03%     9846     86   1548     1062k   316.7s\n",
+      " T    8884     171      1208  39.38%   0.0202044379    0.1006031462      79.92%     9912     93   1578     1070k   319.3s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      " T    8891     120      1211  40.85%   0.0202044379    0.0935000065      78.39%     9915     93   1580     1071k   319.5s\n",
+      " T    8898     120      1215  40.85%   0.0202044379    0.0931519259      78.31%     9919     93   1585     1071k   319.6s\n",
+      " T    8920     120      1225  40.85%   0.0202044379    0.0930568574      78.29%     9929     93   1601     1072k   320.0s\n",
+      " T    8965     105      1239  41.28%   0.0202044379    0.0859343767      76.49%    10050    100   1619     1075k   321.2s\n",
+      " T    8970      99      1242  41.69%   0.0202044379    0.0826614026      75.56%    10053    100   1621     1075k   321.3s\n",
+      " T    9002      86      1257  46.63%   0.0202044379    0.0785995753      74.29%    10066    100   1637     1078k   322.1s\n",
+      " T    9164     119      1316  46.67%   0.0202044379    0.0771396194      73.81%     9704     54   1693     1090k   326.2s\n",
+      "      9285     137      1369  47.35%   0.02286829      0.0771396194      70.35%     8251     57   1752     1105k   331.4s\n",
+      " T    9301     117      1375  60.46%   0.02286829      0.0719610622      68.22%     8256     57   1757     1106k   331.8s\n",
+      " T    9304     109      1377  60.47%   0.02286829      0.0705787676      67.60%     8257     57   1758     1106k   331.9s\n",
+      " T    9319      77      1384  60.68%   0.02286829      0.0640056205      64.27%     8262     57   1764     1107k   332.1s\n",
+      " T    9348      37      1397  64.45%   0.02286829      0.0502852709      54.52%     8272     57   1774     1109k   332.8s\n",
+      " T    9403      43      1417  66.92%   0.02286829      0.0462748346      50.58%     8309     61   1794     1114k   334.3s\n",
+      "      9522      59      1472  88.96%   0.02286829      0.0462748346      50.58%     9645     48   1847     1126k   339.4s\n",
+      "      9614      64      1511  90.86%   0.0285839663    0.0462748346      38.23%     8644     99   1898     1138k   345.2s\n",
+      "      9735      79      1560  93.09%   0.0285839663    0.0462748346      38.23%    10086     82   1963     1153k   350.2s\n",
+      " T    9762      77      1570  93.14%   0.0285839663    0.0460846816      37.98%    10095     82   1978     1154k   350.7s\n",
+      "      9860      97      1612  93.53%   0.0297893072    0.0460846816      35.36%     8848     77   2040     1164k   355.9s\n",
+      "      9986     115      1663  94.02%   0.0299705275    0.0460846816      34.97%     8833     65   2110     1176k   361.1s\n",
+      "     10049     109      1700  94.33%   0.0304193203    0.0460846816      33.99%     8270     80   2171     1187k   366.5s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "     10147     106      1749  94.78%   0.0331486664    0.0460846816      28.07%     8095     62   2233     1197k   371.5s\n",
+      "     10225      60      1811  98.10%   0.0390949049    0.0460846816      15.17%     7431     84   2337     1214k   377.1s\n",
+      "     10285      18      1862  98.81%   0.0405902561    0.0460846816      11.92%     7800     67   2409     1227k   382.2s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.0460846815889\n",
+      "  Dual bound        0.0460828522316\n",
+      "  Gap               0.00397% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.0460846815889 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    0 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            386.12 (total)\n",
+      "                    0.13 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             10319\n",
+      "  LP iterations     1236081 (total)\n",
+      "                    172574 (strong br.)\n",
+      "                    33659 (separation)\n",
+      "                    98217 (heuristics)\n",
+      "1062.210358 seconds (1.81 M allocations: 63.485 MiB)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 59.1741\n",
-       "  :TotalTime          => 359.826\n",
-       "  :Perturbation       => GenericAffExpr{Float64,VariableRef}[noname noname … no…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 386.127\n",
+       "  :TotalTime          => 1062.21\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
        "  :TighteningApproach => \"mip\"\n",
        "  :PerturbationFamily => unrestricted\n",
        "  :SolveStatus        => OPTIMAL\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[-0.012063867412507…\n",
+       "  :Output             => AffExpr[-0.012063867412507534 _[865] + 0.6606525778770…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 28,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1929,8 +1634,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"output_flag\" => true),\n",
     "    tightening_algorithm = mip,\n",
     "    norm_order=Inf\n",
     ")"
@@ -1942,7 +1647,7 @@
    "source": [
     "We can also modify many of the parameters of the solver to change behavior:\n",
     "\n",
-    "We will be focusing on the parameters available via Gurobi (http://www.gurobi.com/documentation/9.0/refman/parameters.html), but other solvers often have similar options."
+    "We will be focusing on the parameters available via [Gurobi](http://www.gurobi.com/documentation/11.0/refman/parameters.html) and [HiGHS](https://ergo-code.github.io/HiGHS/stable/options/definitions/), but other solvers often have similar options."
    ]
   },
   {
@@ -1953,7 +1658,7 @@
     "### `main_solve_options`\n",
     "\n",
     "#### Muting Output\n",
-    "To mute the output from the `GurobiSolver`, set `OutputFlag=0`.\n"
+    "To mute the output from the `Gurobi`, set `OutputFlag=0`; for `HiGHS`, set `output_flag=false`.\n"
    ]
   },
   {
@@ -1984,123 +1689,79 @@
    "metadata": {},
    "source": [
     "##### Terminate if time limit is reached\n",
-    "Set `TimeLimit`:"
+    "Set `TimeLimit` for `Gurobi`, and `time_limit` for `HiGHS`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  10%|██▎                    |  ETA: 0:00:01\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Gurobi Optimizer version 9.0.2 build v9.0.2rc0 (linux64)\n",
-      "Optimize a model with 1263 rows, 1020 columns and 66888 nonzeros\n",
-      "Model fingerprint: 0x0202e6a7\n",
-      "Variable types: 960 continuous, 60 integer (60 binary)\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [2e-05, 7e+02]\n",
-      "  Objective range  [1e+00, 1e+00]\n",
-      "  Bounds range     [5e-01, 3e+02]\n",
-      "  RHS range        [4e-03, 7e+02]\n",
-      "Presolve added 0 rows and 10 columns\n",
-      "Presolve removed 50 rows and 0 columns\n",
-      "Presolve time: 0.11s\n",
-      "Presolved: 1213 rows, 1030 columns, 62933 nonzeros\n",
-      "Variable types: 970 continuous, 60 integer (60 binary)\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
       "\n",
-      "Root relaxation: objective 0.000000e+00, 837 iterations, 0.07 seconds\n",
+      "Solving MIP model with:\n",
+      "   1203 rows\n",
+      "   1020 cols (60 binary, 0 integer, 0 implied int., 960 continuous)\n",
+      "   66828 nonzeros\n",
       "\n",
-      "    Nodes    |    Current Node    |     Objective Bounds      |     Work\n",
-      " Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "     0     0    0.00000    0    1          -    0.00000      -     -    0s\n",
-      "H    0     0                       0.4967121    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     2    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "H   29    31                       0.3535137    0.00000   100%   429    2s\n",
-      "    88   102    0.02818   25    9    0.35351    0.00000   100%   379    5s\n",
-      "H   95   102                       0.2051025    0.00000   100%   369    5s\n",
-      "*  145   139              42       0.2051025    0.00000   100%   320    6s\n",
-      "   254   228    0.15085   15    8    0.20510    0.00000   100%   273   10s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     36      1504     0.1s\n",
+      " R       0       0         0   0.00%   0               0.2260962872     100.00%     2331     37    517      1954     1.3s\n",
+      " L       0       0         0   0.00%   0               0.1244550462     100.00%     2331     37    517      1954    10.0s\n",
       "\n",
-      "Cutting planes:\n",
-      "  MIR: 3\n",
-      "  Flow cover: 4\n",
-      "\n",
-      "Explored 300 nodes (75240 simplex iterations) in 10.00 seconds\n",
-      "Thread count was 4 (of 4 available processors)\n",
-      "\n",
-      "Solution count 3: 0.205102 0.353514 0.496712 \n",
-      "\n",
-      "Time limit reached\n",
-      "Best objective 2.051024945226e-01, best bound 0.000000000000e+00, gap 100.0000%\n",
-      " 10.854215 seconds (2.07 M allocations: 68.026 MiB)\n"
+      "Solving report\n",
+      "  Status            Time limit reached\n",
+      "  Primal bound      0.124455046182\n",
+      "  Dual bound        0\n",
+      "  Gap               100% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.124455046182 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    2.22044604925e-16 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            10.00 (total)\n",
+      "                    0.02 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             0\n",
+      "  LP iterations     23376 (total)\n",
+      "                    0 (strong br.)\n",
+      "                    450 (separation)\n",
+      "                    21422 (heuristics)\n",
+      " 10.397745 seconds (1.90 M allocations: 72.457 MiB)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 10.0028\n",
-       "  :TotalTime          => 10.8295\n",
-       "  :Perturbation       => GenericAffExpr{Float64,VariableRef}[noname noname … no…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 10.0061\n",
+       "  :TotalTime          => 10.3976\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
        "  :TighteningApproach => \"lp\"\n",
        "  :PerturbationFamily => unrestricted\n",
        "  :SolveStatus        => TIME_LIMIT\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[-0.012063867412507…\n",
+       "  :Output             => AffExpr[-0.012063867412507534 _[865] + 0.6606525778770…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 23,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -2108,8 +1769,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"TimeLimit\" => 10),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"time_limit\" => 10.0),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf\n",
     ")"
@@ -2121,7 +1782,7 @@
    "source": [
     "##### Terminate if lower bound on robustness proved\n",
     "\n",
-    "Set `BestBdStop`."
+    "Set `BestBdStop` for `Gurobi`, and `objective_bound` for `HiGHS`."
    ]
   },
   {
@@ -2133,125 +1794,76 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  40%|█████████▎             |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Gurobi Optimizer version 9.0.2 build v9.0.2rc0 (linux64)\n",
-      "Optimize a model with 1263 rows, 1020 columns and 66888 nonzeros\n",
-      "Model fingerprint: 0x0202e6a7\n",
-      "Variable types: 960 continuous, 60 integer (60 binary)\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [2e-05, 7e+02]\n",
-      "  Objective range  [1e+00, 1e+00]\n",
-      "  Bounds range     [5e-01, 3e+02]\n",
-      "  RHS range        [4e-03, 7e+02]\n",
-      "Presolve added 0 rows and 10 columns\n",
-      "Presolve removed 50 rows and 0 columns\n",
-      "Presolve time: 0.09s\n",
-      "Presolved: 1213 rows, 1030 columns, 62933 nonzeros\n",
-      "Variable types: 970 continuous, 60 integer (60 binary)\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
       "\n",
-      "Root relaxation: objective 0.000000e+00, 837 iterations, 0.07 seconds\n",
+      "Solving MIP model with:\n",
+      "   1203 rows\n",
+      "   1020 cols (60 binary, 0 integer, 0 implied int., 960 continuous)\n",
+      "   66828 nonzeros\n",
       "\n",
-      "    Nodes    |    Current Node    |     Objective Bounds      |     Work\n",
-      " Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "     0     0    0.00000    0    1          -    0.00000      -     -    0s\n",
-      "H    0     0                       0.4967121    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     2    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "H   29    31                       0.3535137    0.00000   100%   429    2s\n",
-      "    88   102    0.02818   25    9    0.35351    0.00000   100%   379    5s\n",
-      "H   95   102                       0.2051025    0.00000   100%   369    5s\n",
-      "*  145   139              42       0.2051025    0.00000   100%   320    6s\n",
-      "   313   263    0.10418   23   10    0.20510    0.00000   100%   242   10s\n",
-      "H  315   227                       0.1476387    0.00000   100%   241   10s\n",
-      "H  360   216                       0.1309385    0.00000   100%   226   11s\n",
-      "   599   286    0.12051   22   11    0.13094    0.00000   100%   186   15s\n",
-      "*  736   285              40       0.1084155    0.00000   100%   178   18s\n",
-      "H  764   249                       0.0958362    0.00000   100%   178   19s\n",
-      "   765   248    0.09385   21    2    0.09584    0.00000   100%   178   20s\n",
-      "H  810   268                       0.0696157    0.00000   100%   176   22s\n",
-      "   871   273    0.03477   19    9    0.06962    0.00447  93.6%   175   25s\n",
-      "*  892   259              42       0.0574457    0.00447  92.2%   172   25s\n",
-      "*  893   246              42       0.0574449    0.00447  92.2%   172   25s\n",
-      "* 1148   201              41       0.0564840    0.02084  63.1%   156   29s\n",
-      "* 1149   191              41       0.0537551    0.02084  61.2%   156   29s\n",
+      "         0       0         0   0.00%   0               0.02*                inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               0.02*                inf        0      0     36      1504     0.1s\n",
+      "         0       0         0   0.00%   0               0.02*                inf     1861     25    100     18761     9.0s\n",
       "\n",
-      "Cutting planes:\n",
-      "  Gomory: 5\n",
-      "  Projected implied bound: 3\n",
-      "  MIR: 1\n",
-      "  Flow cover: 3\n",
+      "26.7% inactive integer columns, restarting\n",
+      "Model after restart has 1109 rows, 963 cols (23 bin., 0 int., 0 impl., 940 cont.), and 28917 nonzeros\n",
       "\n",
-      "Explored 1153 nodes (180859 simplex iterations) in 29.40 seconds\n",
-      "Thread count was 4 (of 4 available processors)\n",
+      "         0       0         0   0.00%   0               0.02*                inf        5      0      0     18761     9.2s\n",
+      "         0       0         0   0.00%   0               0.02*                inf        5      0     10     19398     9.2s\n",
       "\n",
-      "Solution count 10: 0.0537551 0.056484 0.0574449 ... 0.205102\n",
+      "4.3% inactive integer columns, restarting\n",
+      "Model after restart has 1107 rows, 962 cols (22 bin., 0 int., 0 impl., 940 cont.), and 28888 nonzeros\n",
       "\n",
-      "Optimization achieved user objective limit\n",
-      "Best objective 5.375506126689e-02, best bound 2.084402587199e-02, gap 61.2241%\n",
-      " 30.399972 seconds (2.31 M allocations: 80.203 MiB, 0.22% gc time)\n"
+      "         0       0         0   0.00%   0.0025720269    0.02*                inf       19      0      0     21505    12.5s\n",
+      "         0       0         0   0.00%   0.00257202869   0.02*                inf       19     19      6     22200    12.6s\n",
+      "         0       0         0   0.00%   0.00451757418   0.02*                inf     2848     52     54     22810    17.8s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Infeasible\n",
+      "  Primal bound      inf\n",
+      "  Dual bound        inf\n",
+      "  Gap               inf\n",
+      "  Solution status   -\n",
+      "  Timing            19.69 (total)\n",
+      "                    0.23 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             1\n",
+      "  LP iterations     28939 (total)\n",
+      "                    5423 (strong br.)\n",
+      "                    3569 (separation)\n",
+      "                    16473 (heuristics)\n",
+      "ERROR:   No invertible representation for getDualRay\n",
+      " 20.191234 seconds (2.13 M allocations: 85.322 MiB, 0.59% compilation time)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 29.3971\n",
-       "  :TotalTime          => 30.2711\n",
-       "  :Perturbation       => GenericAffExpr{Float64,VariableRef}[noname noname … no…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 19.6953\n",
+       "  :TotalTime          => 20.1219\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
        "  :TighteningApproach => \"lp\"\n",
        "  :PerturbationFamily => unrestricted\n",
-       "  :SolveStatus        => OBJECTIVE_LIMIT\n",
+       "  :SolveStatus        => INFEASIBLE\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[-0.012063867412507…\n",
+       "  :Output             => AffExpr[-0.012063867412507534 _[865] + 0.6606525778770…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 24,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -2259,8 +1871,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"BestBdStop\" => 0.02),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"objective_bound\" => 0.02),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf\n",
     ")"
@@ -2272,7 +1884,7 @@
    "source": [
     "##### Terminate if adversarial example found closer than expected robustness\n",
     "\n",
-    "Set `BestObjStop`."
+    "Set `BestObjStop` for `Gurobi`, and `objective_target` for `HiGHS`."
    ]
   },
   {
@@ -2284,113 +1896,193 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  30%|██████▉                |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Gurobi Optimizer version 9.0.2 build v9.0.2rc0 (linux64)\n",
-      "Optimize a model with 1263 rows, 1020 columns and 66888 nonzeros\n",
-      "Model fingerprint: 0x0202e6a7\n",
-      "Variable types: 960 continuous, 60 integer (60 binary)\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [2e-05, 7e+02]\n",
-      "  Objective range  [1e+00, 1e+00]\n",
-      "  Bounds range     [5e-01, 3e+02]\n",
-      "  RHS range        [4e-03, 7e+02]\n",
-      "Presolve added 0 rows and 10 columns\n",
-      "Presolve removed 50 rows and 0 columns\n",
-      "Presolve time: 0.07s\n",
-      "Presolved: 1213 rows, 1030 columns, 62933 nonzeros\n",
-      "Variable types: 970 continuous, 60 integer (60 binary)\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
       "\n",
-      "Root relaxation: objective 0.000000e+00, 837 iterations, 0.05 seconds\n",
+      "Solving MIP model with:\n",
+      "   1203 rows\n",
+      "   1020 cols (60 binary, 0 integer, 0 implied int., 960 continuous)\n",
+      "   66828 nonzeros\n",
       "\n",
-      "    Nodes    |    Current Node    |     Objective Bounds      |     Work\n",
-      " Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "     0     0    0.00000    0    1          -    0.00000      -     -    0s\n",
-      "H    0     0                       0.4967121    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     2    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "H   29    31                       0.3535137    0.00000   100%   429    1s\n",
-      "    67    89    0.01071   20   16    0.35351    0.00000   100%   423    5s\n",
-      "H   95   102                       0.2051025    0.00000   100%   369    5s\n",
-      "*  145   139              42       0.2051025    0.00000   100%   320    7s\n",
-      "   254   233    0.15085   15    8    0.20510    0.00000   100%   273   10s\n",
-      "H  315   227                       0.1476387    0.00000   100%   241   11s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     36      1504     0.1s\n",
+      " R       0       0         0   0.00%   0               0.2260962872     100.00%     2331     37    517      1954     1.2s\n",
+      " L       0       0         0   0.00%   0               0.1207006013     100.00%     2331     37    517      1954    17.7s\n",
+      "        30       3         5   0.00%   0               0.1207006013     100.00%     2351     25    540     91672    22.9s\n",
+      "        47       6        13   0.00%   0               0.1207006013     100.00%     2371     25    569    121937    29.1s\n",
+      "        75       8        27   0.03%   0               0.1207006013     100.00%     2408     25    624    145223    34.1s\n",
+      "       150      30        51   3.21%   0               0.1207006013     100.00%     2595     28    698    169067    39.3s\n",
+      "       279      62       105   3.66%   0               0.1207006013     100.00%     2794     24    857    190646    44.4s\n",
+      "       380      83       144   5.26%   0               0.1207006013     100.00%     2965     28    936    216571    49.4s\n",
+      "       511     113       198   7.34%   0               0.1207006013     100.00%     3497     36   1029    246199    55.5s\n",
+      "       641     133       251   8.14%   0               0.1207006013     100.00%     3587     42   1117    269990    60.6s\n",
+      "       801     162       318   8.92%   0               0.1207006013     100.00%     4411     60   1208    292809    65.6s\n",
+      "       892     179       354   9.20%   0               0.1207006013     100.00%     4501     67   1273    316203    70.6s\n",
+      "       975     187       392   9.59%   0               0.1207006013     100.00%     4962     68   1344    339590    75.8s\n",
+      "      1121     194       461  11.14%   0               0.1207006013     100.00%     5127     59   1487    365961    81.1s\n",
+      "      1387     252       563  11.93%   0               0.1207006013     100.00%     5101     70   1637    389021    86.2s\n",
+      "      1631     306       659  12.06%   0               0.1207006013     100.00%     4712     33   1787    420206    92.4s\n",
+      "      1866     340       758  12.11%   0               0.1207006013     100.00%     4470     41   1908    445735    97.4s\n",
+      "      1979     353       809  12.17%   0               0.1207006013     100.00%     4867     73   1985    467604   102.4s\n",
       "\n",
-      "Cutting planes:\n",
-      "  Implied bound: 2\n",
-      "  MIR: 3\n",
-      "  Flow cover: 4\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "Explored 349 nodes (80689 simplex iterations) in 11.58 seconds\n",
-      "Thread count was 4 (of 4 available processors)\n",
+      "      2046     354       843  17.26%   0               0.1207006013     100.00%     5341     91   2051    484751   107.5s\n",
+      "      2099     354       869  18.39%   0               0.1207006013     100.00%     5371     91   2110    506422   112.5s\n",
+      "      2223     367       922  18.45%   0               0.1207006013     100.00%     5005     35   2195    529729   117.6s\n",
+      "      2421     412       998  18.47%   0               0.1207006013     100.00%     4698     45   2297    560674   123.2s\n",
+      "      2618     440      1084  18.48%   0               0.1207006013     100.00%     4629     55   2418    589772   130.7s\n",
+      "      2754     470      1136  18.48%   0               0.1207006013     100.00%     4479     36   2495    613498   136.3s\n",
+      "      2863     485      1182  19.00%   0               0.1207006013     100.00%     4880     65   2557    634866   141.3s\n",
+      "      3019     518      1244  21.15%   0               0.1207006013     100.00%     5261     59   2678    657805   147.1s\n",
+      "      3222     540      1334  21.16%   0               0.1207006013     100.00%     4204     52   2848    684903   153.5s\n",
+      "      3420     561      1424  21.16%   0               0.1207006013     100.00%     4337     62   2996    710144   158.6s\n",
+      "      3618     586      1509  21.16%   0               0.1207006013     100.00%     4370     54   3102    732712   163.6s\n",
+      "      3776     601      1578  21.17%   0               0.1207006013     100.00%     4457     50   3209    751994   168.6s\n",
+      " T    3899     142      1628  28.11%   0               0.0942444257     100.00%     4480     54   3270    765037   171.6s\n",
+      " T    3908     141      1632  28.11%   0               0.0936965516     100.00%     4484     54   3273    765423   171.7s\n",
+      "      4085     168      1708  32.59%   0               0.0936965516     100.00%     4743     31   3428    790164   176.8s\n",
+      "      4318     200      1810  33.07%   0               0.0936965516     100.00%     4912     44   3622    814536   181.8s\n",
+      "      4432     210      1863  33.20%   0               0.0936965516     100.00%     5150    101   3711    845771   189.9s\n",
+      "      4534     212      1912  33.54%   0               0.0936965516     100.00%     5051    111   3823    871244   195.0s\n",
+      "      4616     215      1951  33.97%   0               0.0936965516     100.00%     5088    111   3937    891790   200.0s\n",
+      "      4746     222      2012  35.49%   0               0.0936965516     100.00%     5479     53   4119    911313   205.0s\n",
       "\n",
-      "Solution count 4: 0.147639 0.205102 0.353514 0.496712 \n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "Optimization achieved user objective limit\n",
-      "Best objective 1.476386863211e-01, best bound 0.000000000000e+00, gap 100.0000%\n",
-      " 12.117183 seconds (2.07 M allocations: 68.014 MiB)\n"
+      "      4833     228      2054  35.88%   0               0.0936965516     100.00%     6096     77   4242    928367   210.3s\n",
+      "      5039     258      2141  35.89%   0               0.0936965516     100.00%     6763     60   4396    950565   216.2s\n",
+      "      5069     255      2157  37.06%   0               0.0936965516     100.00%     6261    140   4426    964519   221.2s\n",
+      "      5154     260      2197  37.51%   0               0.0936965516     100.00%     6485    149   4508    984868   226.6s\n",
+      "      5237     260      2239  37.66%   0               0.0936965516     100.00%     6525    149   4595     1005k   231.7s\n",
+      "      5300     261      2268  40.72%   0               0.0936965516     100.00%     6912     61   4645     1022k   236.8s\n",
+      "      5507     300      2350  45.41%   0               0.0936965516     100.00%     7028     78   4791     1037k   241.8s\n",
+      "      5587     312      2387  46.78%   0               0.0936965516     100.00%     9326    100   4901     1049k   246.8s\n",
+      "      5636     309      2413  48.01%   0               0.0936965516     100.00%     9703     83   4943     1063k   252.1s\n",
+      "      5748     319      2463  51.04%   0               0.0936965516     100.00%     9999     94   5060     1083k   257.1s\n",
+      "      5980     373      2549  52.08%   4.39241073e-05  0.0936965516      99.95%    10038    111   5191     1098k   262.2s\n",
+      "      6147     405      2619  52.16%   4.39241073e-05  0.0936965516      99.95%     9721     42   5297     1115k   267.5s\n",
+      " T    6325     424      2681  52.28%   4.39241073e-05  0.0933310059      99.95%    10026     46   5371     1132k   271.9s\n",
+      " L    6340      94      2687  68.08%   4.39241073e-05  0.0592820117      99.93%     9899     50   5378     1133k   293.2s\n",
+      "      6464     108      2741  68.08%   4.39241073e-05  0.0592820117      99.93%     9763     81   5452     1239k   300.0s\n",
+      "      6512     109      2761  68.44%   4.39241073e-05  0.0592820117      99.93%     9547     68   5476     1259k   305.1s\n",
+      "      6632     131      2813  68.46%   4.39241073e-05  0.0592820117      99.93%     9498     68   5547     1276k   310.3s\n",
+      "      6787     150      2879  68.52%   4.39241073e-05  0.0592820117      99.93%     9303     73   5648     1295k   315.3s\n",
+      "      6885     167      2918  68.62%   0.000211862717  0.0592820117      99.64%     9435     59   5699     1311k   320.4s\n",
+      " T    6892     159      2920  68.72%   0.000211862717  0.0584730533      99.64%     9437     59   5701     1311k   320.5s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "      6936     161      2945  68.79%   0.000211862717  0.0584730533      99.64%     9628     72   5730     1327k   325.6s\n",
+      "      7093     184      3010  71.25%   0.00406013893   0.0584730533      93.06%    10457     94   5827     1344k   330.6s\n",
+      "      7272     222      3080  71.37%   0.00406013893   0.0584730533      93.06%     9833     55   5934     1362k   335.8s\n",
+      "      7359     229      3121  71.41%   0.00406013893   0.0584730533      93.06%     9974     68   6012     1380k   341.1s\n",
+      "      7506     256      3181  71.52%   0.00406013893   0.0584730533      93.06%     9403     78   6099     1401k   346.6s\n",
+      "      7607     265      3226  71.54%   0.00406013893   0.0584730533      93.06%     9785     85   6161     1419k   351.7s\n",
+      "      7653     277      3244  72.33%   0.00436601528   0.0584730533      92.53%    10012     65   6185     1431k   357.3s\n",
+      "      7807     292      3312  72.78%   0.00436601528   0.0584730533      92.53%    10129     98   6311     1450k   362.3s\n",
+      "      7969     308      3386  72.98%   0.00436601528   0.0584730533      92.53%     9936    117   6429     1470k   369.1s\n",
+      "      8040     307      3422  75.13%   0.0044718657    0.0584730533      92.35%     9841     59   6485     1488k   374.2s\n",
+      "      8185     326      3483  76.48%   0.0044718657    0.0584730533      92.35%     9310     60   6569     1503k   379.2s\n",
+      "      8339     342      3553  76.50%   0.0044718657    0.0584730533      92.35%     9803     74   6699     1523k   384.2s\n",
+      "      8458     359      3603  77.92%   0.0044718657    0.0584730533      92.35%     9066     42   6759     1543k   389.3s\n",
+      "      8569     365      3655  78.44%   0.0044718657    0.0584730533      92.35%     9965     68   6831     1562k   394.3s\n",
+      "      8758     379      3742  79.19%   0.0044718657    0.0584730533      92.35%    10122     35   6958     1579k   399.4s\n",
+      "      8888     390      3802  79.26%   0.0044718657    0.0584730533      92.35%     9238     52   7047     1597k   404.4s\n",
+      "      9006     390      3861  79.79%   0.0044718657    0.0584730533      92.35%     9849     59   7122     1616k   409.5s\n",
+      "      9063     386      3891  80.07%   0.00598983999   0.0584730533      89.76%     9736     50   7158     1631k   414.5s\n",
+      "      9168     386      3942  80.96%   0.00598983999   0.0584730533      89.76%     9993     63   7241     1649k   419.6s\n",
+      "      9310     406      4005  82.05%   0.00598983999   0.0584730533      89.76%    10489     76   7357     1667k   424.9s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "      9495     429      4085  82.10%   0.00598983999   0.0584730533      89.76%     9488     42   7516     1686k   430.0s\n",
+      "      9662     455      4153  82.12%   0.00598983999   0.0584730533      89.76%     9765     51   7620     1703k   435.0s\n",
+      "      9724     462      4183  82.13%   0.00598983999   0.0584730533      89.76%     9129     90   7666     1712k   440.5s\n",
+      "      9861     475      4244  82.14%   0.00598983999   0.0584730533      89.76%    10095     78   7755     1729k   445.5s\n",
+      "      9982     492      4298  82.15%   0.00599172376   0.0584730533      89.75%     7654     83   7836     1748k   450.6s\n",
+      "     10104     513      4346  82.15%   0.00599172376   0.0584730533      89.75%     8425     94   7898     1766k   455.6s\n",
+      "\n",
+      "Restarting search from the root node\n",
+      "Model after restart has 1152 rows, 990 cols (39 bin., 0 int., 0 impl., 951 cont.), and 42855 nonzeros\n",
+      "\n",
+      "     10182       0         0   0.00%   0.00599172376   0.0584730533      89.75%       90      0      0     1780k   459.7s\n",
+      "     10182       0         0   0.00%   0.00599172376   0.0584730533      89.75%       90      9      9     1781k   459.8s\n",
+      "     10401      29        89  53.21%   0.00599172376   0.0584730533      89.75%     1222     26    148     1801k   464.9s\n",
+      "     10587      57       168  70.08%   0.00599172376   0.0584730533      89.75%     3366     53    283     1830k   471.4s\n",
+      "     10836      95       262  74.17%   0.0070120559    0.0584730533      88.01%     4494     46    412     1850k   476.6s\n",
+      "     10965     112       317  80.94%   0.0070120559    0.0584730533      88.01%     5549     55    493     1867k   482.9s\n",
+      "     11139     145       385  82.52%   0.0146594215    0.0584730533      74.93%     4710     50    604     1885k   488.9s\n",
+      "     11317     176       457  85.03%   0.0176698194    0.0584730533      69.78%     4893     51    692     1902k   493.9s\n",
+      "     11516     220       535  85.17%   0.0223330481    0.0584730533      61.81%     5411     48    792     1916k   499.1s\n",
+      "     11638     222       589  86.93%   0.0224681328    0.0584730533      61.58%     5291     33    854     1931k   504.2s\n",
+      " T   11676     174       606  88.29%   0.0224681328    0.0554554748      59.48%     5431     35    871     1937k   506.1s\n",
+      " T   11687     118       612  93.91%   0.0224681328    0.0498354344      54.92%     5437     35    877     1937k   506.3s\n",
+      " T   11730      97       633  94.22%   0.0224681328    0.0460846816      51.25%     5457     35    897     1939k   506.9s\n",
+      "     11835     103       682  95.19%   0.0317301163    0.0460846816      31.15%     6578     55    981     1952k   512.0s\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "     11926      94       732  95.41%   0.0354774217    0.0460846816      23.02%     6661     26   1043     1966k   517.2s\n",
+      "     11987      75       773  95.63%   0.0365260193    0.0460846816      20.74%     5865     27   1094     1978k   522.5s\n",
+      "     12090      67       822  96.13%   0.037204082     0.0460846816      19.27%     5267     49   1164     1990k   528.1s\n",
+      "     12154      51       862  97.74%   0.0389159787    0.0460846816      15.56%     4599     46   1206     2004k   533.4s\n",
+      "     12197      38       890  97.93%   0.0397913885    0.0460846816      13.66%     5137     40   1242     2014k   538.4s\n",
+      "     12261      25       928  99.16%   0.0416131647    0.0460846816       9.70%     5358     45   1294     2023k   543.6s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.0460846815889\n",
+      "  Dual bound        0.0460828522316\n",
+      "  Gap               0.00397% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.0460846815889 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    0 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            547.73 (total)\n",
+      "                    0.12 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             12314\n",
+      "  LP iterations     2037617 (total)\n",
+      "                    139358 (strong br.)\n",
+      "                    70276 (separation)\n",
+      "                    149604 (heuristics)\n",
+      "548.116698 seconds (1.90 M allocations: 72.457 MiB)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 11.5785\n",
-       "  :TotalTime          => 12.0981\n",
-       "  :Perturbation       => GenericAffExpr{Float64,VariableRef}[noname noname … no…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 547.737\n",
+       "  :TotalTime          => 548.117\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
        "  :TighteningApproach => \"lp\"\n",
        "  :PerturbationFamily => unrestricted\n",
-       "  :SolveStatus        => OBJECTIVE_LIMIT\n",
+       "  :SolveStatus        => OPTIMAL\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[-0.012063867412507…\n",
+       "  :Output             => AffExpr[-0.012063867412507534 _[865] + 0.6606525778770…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 25,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -2398,8 +2090,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"BestObjStop\" => 0.2),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"objective_target\" => 0.2),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf\n",
     ")"
@@ -2409,9 +2101,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Terminate if gap between `Incumbent` and `BestBd` is below threshold\n",
+    "##### Terminate if gap between the incumbent and the best bound is below threshold\n",
     "\n",
-    "Set `MIPGap`."
+    "Set `MIPGap` for `Gurobi`, and `mip_abs_gap` for `HiGHS`."
    ]
   },
   {
@@ -2423,127 +2115,66 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m  Calculating upper bounds:  20%|████▋                  |  ETA: 0:00:00\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n",
-      "Gurobi Optimizer version 9.0.2 build v9.0.2rc0 (linux64)\n",
-      "Optimize a model with 1263 rows, 1020 columns and 66888 nonzeros\n",
-      "Model fingerprint: 0x0202e6a7\n",
-      "Variable types: 960 continuous, 60 integer (60 binary)\n",
-      "Coefficient statistics:\n",
-      "  Matrix range     [2e-05, 7e+02]\n",
-      "  Objective range  [1e+00, 1e+00]\n",
-      "  Bounds range     [5e-01, 3e+02]\n",
-      "  RHS range        [4e-03, 7e+02]\n",
-      "Presolve added 0 rows and 10 columns\n",
-      "Presolve removed 50 rows and 0 columns\n",
-      "Presolve time: 0.09s\n",
-      "Presolved: 1213 rows, 1030 columns, 62933 nonzeros\n",
-      "Variable types: 970 continuous, 60 integer (60 binary)\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
+      "1203 rows, 1020 cols, 66828 nonzeros\n",
       "\n",
-      "Root relaxation: objective 0.000000e+00, 837 iterations, 0.07 seconds\n",
+      "Solving MIP model with:\n",
+      "   1203 rows\n",
+      "   1020 cols (60 binary, 0 integer, 0 implied int., 960 continuous)\n",
+      "   66828 nonzeros\n",
       "\n",
-      "    Nodes    |    Current Node    |     Objective Bounds      |     Work\n",
-      " Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
       "\n",
-      "     0     0    0.00000    0    1          -    0.00000      -     -    0s\n",
-      "H    0     0                       0.4967121    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     0    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "     0     2    0.00000    0    2    0.49671    0.00000   100%     -    0s\n",
-      "H   29    31                       0.3535137    0.00000   100%   429    2s\n",
-      "H   95   102                       0.2051025    0.00000   100%   369    4s\n",
-      "   101   117    0.05359   29    9    0.20510    0.00000   100%   364    5s\n",
-      "*  145   139              42       0.2051025    0.00000   100%   320    6s\n",
-      "   313   263    0.10418   23   10    0.20510    0.00000   100%   242   10s\n",
-      "H  315   227                       0.1476387    0.00000   100%   241   10s\n",
-      "H  360   216                       0.1309385    0.00000   100%   226   10s\n",
-      "   599   286    0.12051   22   11    0.13094    0.00000   100%   186   16s\n",
-      "*  736   285              40       0.1084155    0.00000   100%   178   18s\n",
-      "H  764   249                       0.0958362    0.00000   100%   178   20s\n",
-      "H  810   268                       0.0696157    0.00000   100%   176   23s\n",
-      "   865   267 infeasible   38         0.06962    0.00447  93.6%   175   25s\n",
-      "*  892   259              42       0.0574457    0.00447  92.2%   172   25s\n",
-      "*  893   246              42       0.0574449    0.00447  92.2%   172   25s\n",
-      "* 1148   201              41       0.0564840    0.02084  63.1%   156   29s\n",
-      "* 1149   191              41       0.0537551    0.02084  61.2%   156   29s\n",
-      "  1199   182     cutoff   26         0.05376    0.02293  57.3%   153   30s\n",
-      "* 1252   168              40       0.0502853    0.02545  49.4%   149   30s\n",
-      "* 1255   145              40       0.0460847    0.02545  44.8%   149   30s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     36      1504     0.2s\n",
+      " R       0       0         0   0.00%   0               0.2260962872     100.00%     2331     37    517      1954     1.2s\n",
       "\n",
-      "Cutting planes:\n",
-      "  Gomory: 5\n",
-      "  Projected implied bound: 3\n",
-      "  MIR: 1\n",
-      "  Flow cover: 3\n",
-      "\n",
-      "Explored 1401 nodes (197770 simplex iterations) in 31.95 seconds\n",
-      "Thread count was 4 (of 4 available processors)\n",
-      "\n",
-      "Solution count 10: 0.0460847 0.0502853 0.0537551 ... 0.130938\n",
-      "\n",
-      "Optimal solution found (tolerance 4.00e-01)\n",
-      "Best objective 4.608468158892e-02, best bound 2.895634473127e-02, gap 37.1671%\n",
-      " 32.665103 seconds (2.07 M allocations: 68.027 MiB)\n"
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.22609628722\n",
+      "  Dual bound        0\n",
+      "  Gap               100% (tolerance: 176.92%)\n",
+      "  Solution status   feasible\n",
+      "                    0.22609628722 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    0 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            1.23 (total)\n",
+      "                    0.02 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             1\n",
+      "  LP iterations     1954 (total)\n",
+      "                    0 (strong br.)\n",
+      "                    450 (separation)\n",
+      "                    0 (heuristics)\n",
+      "  1.617358 seconds (1.90 M allocations: 72.457 MiB)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 31.9488\n",
-       "  :TotalTime          => 32.6446\n",
-       "  :Perturbation       => GenericAffExpr{Float64,VariableRef}[noname noname … no…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 1.23475\n",
+       "  :TotalTime          => 1.61724\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
        "  :TighteningApproach => \"lp\"\n",
        "  :PerturbationFamily => unrestricted\n",
        "  :SolveStatus        => OPTIMAL\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[-0.012063867412507…\n",
+       "  :Output             => AffExpr[-0.012063867412507534 _[865] + 0.6606525778770…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 26,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -2551,8 +2182,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10,\n",
-    "    Gurobi.Optimizer,\n",
-    "    Dict(\"MIPGap\" => 0.4),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"mip_abs_gap\" => 0.4),\n",
     "    tightening_algorithm = lp,\n",
     "    norm_order=Inf\n",
     ")"
@@ -2568,15 +2199,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.4.2",
+   "display_name": "Julia 1.7.1",
    "language": "julia",
-   "name": "julia-1.4"
+   "name": "julia-1.7"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.4.2"
+   "version": "1.7.1"
   }
  },
  "nbformat": 4,

--- a/examples/03_interpreting_the_output_of_find_adversarial_example.ipynb
+++ b/examples/03_interpreting_the_output_of_find_adversarial_example.ipynb
@@ -20,19 +20,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "┌ Info: Precompiling MIPVerify [e5e5f8be-2a6a-5994-adbb-5afbd0e30425]\n",
-      "└ @ Base loading.jl:1260\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "using MIPVerify\n",
-    "using Gurobi\n",
+    "using HiGHS\n",
     "using JuMP\n",
     "using Images\n",
     "\n",
@@ -62,78 +53,68 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating upper bounds:  10%|██▎                    |  ETA: 0:03:39\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:24\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1779 rows, 1627 cols, 56716 nonzeros\n",
+      "1779 rows, 1627 cols, 56716 nonzeros\n",
+      "\n",
+      "Solving MIP model with:\n",
+      "   1779 rows\n",
+      "   1627 cols (29 binary, 0 integer, 0 implied int., 1598 continuous)\n",
+      "   56716 nonzeros\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     13      1616     0.1s\n",
+      "         0       0         0   0.00%   0               inf                  inf     3942     12     99     30330    14.5s\n",
+      " T      15       0         3   1.61%   0               0.0498354344     100.00%     3951     12    109     39558    16.4s\n",
+      " T      27       1        10   3.42%   0               0.0474230913     100.00%     3974     12    131     45590    17.4s\n",
+      " T      45       4        20  77.27%   0.0381825316    0.0460846816      17.15%     4563     15    162     58011    20.3s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.0460846815889\n",
+      "  Dual bound        0.0460846815889\n",
+      "  Gap               0% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.0460846815889 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    0 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            21.61 (total)\n",
+      "                    0.02 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             53\n",
+      "  LP iterations     60163 (total)\n",
+      "                    19015 (strong br.)\n",
+      "                    707 (separation)\n",
+      "                    28049 (heuristics)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
+       "Dict{Any, Any} with 11 entries:\n",
        "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 15.6326\n",
-       "  :TotalTime          => 62.0275\n",
-       "  :Perturbation       => VariableRef[noname noname … noname noname]…\n",
-       "  :PerturbedInput     => VariableRef[noname noname … noname noname]…\n",
+       "  :SolveTime          => 21.6141\n",
+       "  :TotalTime          => 38.8481\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[785] _[786] … _[811] _[812];;; _[813] _[814] … _[83…\n",
        "  :TighteningApproach => \"lp\"\n",
        "  :PerturbationFamily => linf-norm-bounded-0.05\n",
        "  :SolveStatus        => OPTIMAL\n",
        "  :Model              => A JuMP Model…\n",
-       "  :Output             => GenericAffExpr{Float64,VariableRef}[-0.012063867412507…\n",
+       "  :Output             => AffExpr[-0.012063867412507534 _[1601] + 0.660652577877…\n",
        "  :PredictedIndex     => 8"
       ]
      },
-     "execution_count": 2,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -141,9 +122,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10, \n",
-    "    Gurobi.Optimizer,\n",
-    "    # OutputFlag=0 prevents any output from being printed out\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(),\n",
     "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.05),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
@@ -186,9 +166,8 @@
        "2411"
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -206,9 +185,8 @@
        "2381"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -223,12 +201,11 @@
     {
      "data": {
       "text/plain": [
-       "15.632591009140015"
+       "21.61407446861267"
       ]
      },
-     "execution_count": 6,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -250,12 +227,11 @@
     {
      "data": {
       "text/plain": [
-       "0.046084681588922705"
+       "0.046084681588922406"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -270,12 +246,11 @@
     {
      "data": {
       "text/plain": [
-       "0.046084681588922705"
+       "0.046084681588922406"
       ]
      },
-     "execution_count": 8,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -302,9 +277,8 @@
        "linf-norm-bounded-0.05"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -328,13 +302,12 @@
     {
      "data": {
       "text/plain": [
-       "1-element Array{Int64,1}:\n",
+       "1-element Vector{Int64}:\n",
        " 10"
       ]
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -357,46 +330,45 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Academic license - for non-commercial use only\n",
       "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [1, 2, 3, 4, 5, 6, 7, 9, 10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1790 rows, 1637 cols, 64883 nonzeros\n",
+      "1790 rows, 1637 cols, 64883 nonzeros\n",
+      "\n",
+      "Solving MIP model with:\n",
+      "   1790 rows\n",
+      "   1637 cols (38 binary, 0 integer, 0 implied int., 1599 continuous)\n",
+      "   64883 nonzeros\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     17      1272     0.1s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Time limit reached\n",
+      "  Primal bound      inf\n",
+      "  Dual bound        0\n",
+      "  Gap               inf\n",
+      "  Solution status   -\n",
+      "  Timing            5.00 (total)\n",
+      "                    0.03 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             0\n",
+      "  LP iterations     7786 (total)\n",
+      "                    0 (strong br.)\n",
+      "                    2296 (separation)\n",
+      "                    4218 (heuristics)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "9-element Array{Int64,1}:\n",
+       "9-element Vector{Int64}:\n",
        "  1\n",
        "  2\n",
        "  3\n",
@@ -408,9 +380,8 @@
        " 10"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -418,9 +389,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    8,\n",
-    "    Gurobi.Optimizer,\n",
-    "    # OutputFlag=0 prevents any output from being printed out\n",
-    "    Dict(\"OutputFlag\" => 0, \"TimeLimit\" => 5),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(\"time_limit\" => 5.0),\n",
     "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.05),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
@@ -456,9 +426,8 @@
        "OPTIMAL::TerminationStatusCode = 1"
       ]
      },
-     "execution_count": 12,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -483,9 +452,8 @@
        "TIME_LIMIT::TerminationStatusCode = 12"
       ]
      },
-     "execution_count": 13,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -509,7 +477,7 @@
     {
      "data": {
       "text/plain": [
-       "1×28×28×1 Array{Float64,4}:\n",
+       "1×28×28×1 Array{Float64, 4}:\n",
        "[:, :, 1, 1] =\n",
        " 0.0460847  0.0  0.0  0.0460847  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0460847\n",
        "\n",
@@ -519,7 +487,7 @@
        "[:, :, 3, 1] =\n",
        " 0.0  0.0  0.0  0.0  0.0  0.0  0.0460847  …  0.0  0.0  0.0460847  0.0  0.0\n",
        "\n",
-       "...\n",
+       ";;; … \n",
        "\n",
        "[:, :, 26, 1] =\n",
        " 0.0  0.0  0.0460847  0.0  0.0  0.0  0.0  …  0.0460847  0.0460847  0.0  0.0\n",
@@ -531,9 +499,8 @@
        " 0.0460847  0.0  0.0460847  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0460847  0.0"
       ]
      },
-     "execution_count": 14,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -547,7 +514,10 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwBAMAAAA0zul4AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAJ1BMVEXp9v35+Pnr9/3s9/3/7+vx+v7/8Ovx+f7t+P3v+f7/9PH/9vP///9TFX8KAAAAAWJLR0QMgbNRYwAAAVxJREFUWMPVl0EVAjEMRGMBC1jAQi2sBSxgAQtYwALmoCxDJplyZ3KA3Sa/vDdJ2hARh49FzOeI+g1f+uHzAdmReA3PlYz0A+fL8ciypBC55elE0hmBPZcZyILouhNYJVhhnHpPsJf2b1Ta3gbUosZW6amt/G1kG5APpDEixtt6S1dp6JcsQF7csW0bYtM/htxVJiCnePywiO1lVUhPsC9P5HzmDbjlncB86VnlfS+XuREfZG6gqCS6qd8RZBe/zae9wFk0LxBOvUARer2iiZddYQDKdSkGadolZAf2IZ4NI3zzWoG8pAXP0iDCD1wPtnv47YZjmIdEPzDLIIthGoYl3ZDGXBNQ0Wn3O48MKpsT2NsZVrGe/sU58MfgWhpgj4deSOUEMAF5CWFdmm5tsjIBOdFoYYzvOgr7gdzO9c8ZF/9CHCOQ0wxx9suGsfz8HsgmYEqi7loY1W8EPgFw1YaIp86glAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAIAAABJgmMcAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAABOpJREFUeAHtwcFqXVkOhtHPyk/sELgIB/z+r9cGGxFwl50oco2UymCHU+e2qnqy19J//vuD5pacESVW3JIWJY64JS1KHHFLzogSzS1pUWLFLWlRorklLUqsiG2U2EaJbZTckiNRorklK27JGW7JiluyEiVWosQRt2TFLZngljSxjRLbKLGNEn+DW9KiRLMbfooSK25JixItShxxS85wS1qUOBIl2ocbfvrxzlKUaG5JixJNbKPENkpsoxQlVtySFbekRYnmlrQo0aJEc0talGhuyRG3ZMUtORIlVtySFiWaW3KGW9LENkpso8Q2Sm5JixIrUaK5JWe4JS1KNLfkn+SWHIkSzS2ZILZRYhsltlGKEs0tORIlmluy4pa0KNHckhYlmlvy/xYlVtySM8Q2SmyjxDZKbkmLEteKEs0tWYkSzS1ZiRLNLWlRYoJb0tySa0WJ5pY0sY0S2yixjVKUaG5JixJnPLw90x5v72kPb88ceby9Z5pbshIljrglZ0SJJrZRYhsltlFySyY83t7THt6eWfn6+Qvt8vJEe3h75sgD13u8vWfl4e2Z9u3ThRYlmlvSosQRsY0S2yixjVKUmPDw9syRy8sT/5bH23vanW5YeeSen4qf3JIWJY64JU1so8Q2SmyjxP8gSjT/dKFFiSNuSYsSKw9vzyzd8Jd3lh7envnpjaULf/n26cIZbsmK2EaJbZTYRsktWYkSK25JixItSpwRJVbckvbt04WVKHHG3Ycb2uuPd9rD2zMtSjS3ZMUtOSK2UWIbJbZR4jfckpUoMc0tWYkSE+7ev9NeEe3x9p6VKLESJVbckia2UWIbJbZR4iS3pEWJa7klK1HiDLekRYl2pxtapLiWW3KG2EaJbZTYRilKrLglLUo0t6S5JWdEiRYlVtySFiWORIkm4xS35EiUOENso8Q2Smyj5JYccUtWokRzS1qUuFaUuJbshvaa75wRJc5wS1bENkpso8Q2SvwNUaK5JStR4ohb0qLEtO8/3jkjShxxS1qUaFFiRWyjxDZKbKPEL6LEkSjR3JIWJZpbcsQtaVHiWne6ob3mO0fckhYlmlvSosSKW9KixIrYRoltlNhGiV+4JS1KNLfkiFtyLbekRYkjHz/c0C4vT7TX23uaW9KiRIsSzS1pUaK5JS1KnCG2UWIbJbZR4hdR4p8UJZpbsuKWtI9/fGXl6+cvrLglK27JEbfkDLekRYkmtlFiGyW2UeIXbkmLEi1KNLfkWm7JkY/5ypHLyxP/FrekRYkWJVbENkpso8Q2SlHiiFtyJEo0t+Rq379xxrdPF45EieaWtCjR3JIWJc5wS5rYRoltlNhGyS1pUeJabsm1Pv7xlVNu71iJEs0taW7JiltyhlvSokSLEk1so8Q2SmyjxC/ckiNRYsUtWYkSzS2Z8M0+suKWtCgxLUqsuCVNbKPENkpso8RJbsmRKNHckhYl2sPbMytfP3+hXV6eOCNKNLekRYkVt6RFiQliGyW2UWIbJX4jSjS3ZCVKrLglLUo0t+TI5eWJa7klLUo0t2QlSkwT2yixjRLbKPEbbsm1okRzS1qUaA8ce7y9p7klR6JEc0tWokRzS1aiRHNLjkSJJrZRYhsltlGKEituSYsSzS1pbslKlFhxS9rj7T3NLVlxkjPckpUo0dySCVGiuSVNbKPENkpso/4Eb+X0k62YSkIAAAAASUVORK5CYII=",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAIAAABJgmMcAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAABOpJREFUeAHtwcFqXVkOhtHPyk/sELgIB/z+r9cGGxFwl50oco2UymCHU+e2qnqy19J//vuD5pacESVW3JIWJY64JS1KHHFLzogSzS1pUWLFLWlRorklLUqsiG2U2EaJbZTckiNRorklK27JGW7JiluyEiVWosQRt2TFLZngljSxjRLbKLGNEn+DW9KiRLMbfooSK25JixItShxxS85wS1qUOBIl2ocbfvrxzlKUaG5JixJNbKPENkpsoxQlVtySFbekRYnmlrQo0aJEc0talGhuyRG3ZMUtORIlVtySFiWaW3KGW9LENkpso8Q2Sm5JixIrUaK5JWe4JS1KNLfkn+SWHIkSzS2ZILZRYhsltlGKEs0tORIlmluy4pa0KNHckhYlmlvy/xYlVtySM8Q2SmyjxDZKbkmLEteKEs0tWYkSzS1ZiRLNLWlRYoJb0tySa0WJ5pY0sY0S2yixjVKUaG5JixJnPLw90x5v72kPb88ceby9Z5pbshIljrglZ0SJJrZRYhsltlFySyY83t7THt6eWfn6+Qvt8vJEe3h75sgD13u8vWfl4e2Z9u3ThRYlmlvSosQRsY0S2yixjVKUmPDw9syRy8sT/5bH23vanW5YeeSen4qf3JIWJY64JU1so8Q2SmyjxP8gSjT/dKFFiSNuSYsSKw9vzyzd8Jd3lh7envnpjaULf/n26cIZbsmK2EaJbZTYRsktWYkSK25JixItSpwRJVbckvbt04WVKHHG3Ycb2uuPd9rD2zMtSjS3ZMUtOSK2UWIbJbZR4jfckpUoMc0tWYkSE+7ev9NeEe3x9p6VKLESJVbckia2UWIbJbZR4iS3pEWJa7klK1HiDLekRYl2pxtapLiWW3KG2EaJbZTYRilKrLglLUo0t6S5JWdEiRYlVtySFiWORIkm4xS35EiUOENso8Q2Smyj5JYccUtWokRzS1qUuFaUuJbshvaa75wRJc5wS1bENkpso8Q2SvwNUaK5JStR4ohb0qLEtO8/3jkjShxxS1qUaFFiRWyjxDZKbKPEL6LEkSjR3JIWJZpbcsQtaVHiWne6ob3mO0fckhYlmlvSosSKW9KixIrYRoltlNhGiV+4JS1KNLfkiFtyLbekRYkjHz/c0C4vT7TX23uaW9KiRIsSzS1pUaK5JS1KnCG2UWIbJbZR4hdR4p8UJZpbsuKWtI9/fGXl6+cvrLglK27JEbfkDLekRYkmtlFiGyW2UeIXbkmLEi1KNLfkWm7JkY/5ypHLyxP/FrekRYkWJVbENkpso8Q2SlHiiFtyJEo0t+Rq379xxrdPF45EieaWtCjR3JIWJc5wS5rYRoltlNhGyS1pUeJabsm1Pv7xlVNu71iJEs0taW7JiltyhlvSokSLEk1so8Q2SmyjxC/ckiNRYsUtWYkSzS2Z8M0+suKWtCgxLUqsuCVNbKPENkpso8RJbsmRKNHckhYl2sPbMytfP3+hXV6eOCNKNLekRYkVt6RFiQliGyW2UWIbJX4jSjS3ZCVKrLglLUo0t+TI5eWJa7klLUo0t2QlSkwT2yixjRLbKPEbbsm1okRzS1qUaA8ce7y9p7klR6JEc0tWokRzS1aiRHNLjkSJJrZRYhsltlGKEituSYsSzS1pbslKlFhxS9rj7T3NLVlxkjPckpUo0dySCVGiuSVNbKPENkpso/4Eb+X0k62YSkIAAAAASUVORK5C\">"
+      ],
       "text/plain": [
        "28×28 Array{RGB{Float64},2} with eltype RGB{Float64}:\n",
        " RGB{Float64}(0.911923,0.96363,0.991867)   …  RGB{Float64}(0.911923,0.96363,0.991867)\n",
@@ -560,13 +530,7 @@
        " RGB{Float64}(0.911923,0.96363,0.991867)      RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.911923,0.96363,0.991867)      RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.911923,0.96363,0.991867)   …  RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.974944,0.972996,0.976035)\n",
        " ⋮                                         ⋱  \n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
-       " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)     RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.974944,0.972996,0.976035)  …  RGB{Float64}(0.911923,0.96363,0.991867)\n",
        " RGB{Float64}(0.911923,0.96363,0.991867)      RGB{Float64}(0.974944,0.972996,0.976035)\n",
@@ -578,9 +542,8 @@
        " RGB{Float64}(0.911923,0.96363,0.991867)      RGB{Float64}(0.974944,0.972996,0.976035)"
       ]
      },
-     "execution_count": 15,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -604,7 +567,7 @@
     {
      "data": {
       "text/plain": [
-       "1×28×28×1 Array{Float64,4}:\n",
+       "1×28×28×1 Array{Float64, 4}:\n",
        "[:, :, 1, 1] =\n",
        " 0.0460847  0.0  0.0  0.0460847  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0460847\n",
        "\n",
@@ -614,7 +577,7 @@
        "[:, :, 3, 1] =\n",
        " 0.0  0.0  0.0  0.0  0.0  0.0  0.0460847  …  0.0  0.0  0.0460847  0.0  0.0\n",
        "\n",
-       "...\n",
+       ";;; … \n",
        "\n",
        "[:, :, 26, 1] =\n",
        " 0.0  0.0  0.0460847  0.0  0.0  0.0  0.0  …  0.0460847  0.0460847  0.0  0.0\n",
@@ -626,9 +589,8 @@
        " 0.0460847  0.0  0.0460847  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0460847  0.0"
       ]
      },
-     "execution_count": 16,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -642,9 +604,12 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAALHSURBVGje7dq/r0xBFAfwz/LiVx4FiQh5OhIaEREFhY5QKJQaGhWN0EgU/gydSCQanYhQiB9BJRHxM2hQ0L4tJCQU915vdnbm7ja792WyJ9nszNxzZnK/35wzM+fc3jz6BmW+/u8H7Vw/tusn7MOxFaYs5S84F/IQ8hnzE4/PR/9abMPn5UM6fQ7DTuMvfwz7Upv/xf7ZzDEX9Bud8iGd+oK9kKtG2mJiTlIxN6VfPqTdxNIwLuZ8rD9iolxM7vwNy1+wF+I9yidH8SiaR8KmfEinzyGDmJM+T4Y89xM2Ir1YGrvyIZ1+LM1xcghX8BK/cLMe/5SZKPblcEzwrHxIu/FDhrH/iTV1fz0W69+blsm24Bsu4L20z5YPaXfn0lD6OIA9eIvd2IvD2IavWAj0/2AlNtT9a7gonRMoH9LlwSFp/BdUXN7BfpUT/1XF2o94h404hxu1Xbyflg9p97G07bzSPI9t4CSu4wt2YZX0ebZ8SLvjsJFx+It1NuM11uE0brfYlw9pt7k28n6Y46+Pqyr+fuNDxq6zNyx/wd44+bS22sVB3Kvbx/FYPt528oblLzhQtxjnHh+PHav/X+B5i97sTDMxGdgPc9zl+FyLp9iJI3iW0JndDycucwzXjVJxNcXjJRV/Tyzxl8vTzWrAE5OBu8U4Oe2Gi+O4he84gwfStarZfjhxGfLDlMT1/dW4XPfvqvhj2G9F/Vm+dCKSvOOPkofYh884ih8j9Gf74USll6sz5GLrVlU+G06o+Ixt2s5G5UPabR0/lBR/m3C/bl+yxF/DWdv3VM03OeVD2s1+mLqTx3dFOIvtdftRYDMqxxrOWT6kyyPX1kgYE3fgvKVaoowe7ZyWD2l3HOa+q2nGD9XtRdVZJnV3zOVUO33D8hf8z2EuTxr71CucUtXrY722dtMvH9LllfNu4yMl49iXD+nUF/wHg+y5HmmDeFIAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC",
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHAAAABwCAAAAADji6uXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAwtJREFUaAW9wb/rrgUZB+AruqmU24aCCMGkoYZAQiJocGhTjKCppd2mlkNnCSSqPyFoaAkCwVkkooaQwB9LGGRZVEPZ0NRwPoPggfrCfeDx8X3Poem+rmrEWRtBOwTtEGeNoI2gEbRRlpVlZVnFoREjzmLEaKMdYsR1QVlWlpVl5X2Cxl20ETTaIc6CdmjcRRmNoFGWlWVlWbURI2gEjUbQiEOMOLQRNOIsKMvKsrKsgjYacRY04sHi0IjryrKyrCyrRhwaMYJG0Ij/XxtxVpaVZWVZBe1SI0YjRiNo1wVxqRGUZWVZWVaNoJ09hefxO7yLF4y/ui5GO8RZoywry8qyiut+jo/hCTyCb+MO3nJ/n8Y7uIW30QjaoSwry8qyatd9HV/EH/EFPImv4iv4Jx5zuIsP4+N4Av/AdxG0Q1CWlWVlWbmi8QbeMt7ET/EYnsTL+DI+hP/iXfwFf8In8CriLEZZVpaVZRWjjaDRzhr/wUvGG2iHb+Jx/B0vohEjDmVZWVaWlXtitPuL0c4+hZ8YP8RHjDbaCMqysqwsKx8QtEsx2lnwAzyM9/BnZ3FWlpVlZVm1ETSCOGu0EbTD07hlfAN/QBzaWVlWlpVlFYcYjaBdamfPGq/jNYd2FqMsK8vKsvI+jRjtELRLD+EZ4/t4z2iHoNFGWVaWlWXlRjs0gkYcgnZ2G5/Hb/GqETSCNoI2yrKyrCwrN4JGHOJS0MbXcBv/wo8QNBpBI2hnZVlZVpaVG+3BGjGCj+J7xi/wayMOcRY0yrKyrCwrN4JGIy7F2S/xWbyJ5z1Y0GijLCvLyrJqhzg04tKj+JJxC/92aASNoJ0FZVlZVpZV0C7FpU/iV8Zt/MZoBDHiLGg0yrKyrCwrN+LQRoxGjOfwGeMVh6DdXxtBWVaWlWXlA+LQCBqfw3fwCO44awRtBO26sqwsK8vKPY0YbQSN4Ck07uBviEPQiNHurywry8qyck9cagTt8Ht8C+84NGI0YjTi0CjLyrKyrNoIGkGMNoKf4ceui9GI6xpBWVaWlWX/A06qydY5JLkuAAAAAElFTkSuQmCC\">"
+      ],
       "text/plain": [
-       "28×28 reinterpret(Gray{Float64}, ::Array{Float64,2}):\n",
+       "28×28 reinterpret(reshape, Gray{Float64}, ::Matrix{Float64}) with eltype Gray{Float64}:\n",
        " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
@@ -655,13 +620,7 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0460847)  …  Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0)\n",
        " ⋮                         ⋱  \n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
-       " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)           Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0)        …  Gray{Float64}(0.0460847)\n",
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)\n",
@@ -673,9 +632,8 @@
        " Gray{Float64}(0.0460847)     Gray{Float64}(0.0)"
       ]
      },
-     "execution_count": 17,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -700,9 +658,8 @@
        "false"
       ]
      },
-     "execution_count": 18,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -726,22 +683,21 @@
     {
      "data": {
       "text/plain": [
-       "10-element Array{Float64,1}:\n",
-       "  0.674945062874581\n",
-       "  0.6179790360668656\n",
-       "  0.3930321598089366\n",
-       "  0.2965618596703666\n",
-       "  0.24101053495483843\n",
-       "  0.16060021203574887\n",
-       "  0.5428526100447338\n",
-       "  4.288351484573902\n",
-       " -0.22643018233076873\n",
-       "  4.288351484573896"
+       "10-element Vector{Float64}:\n",
+       "  0.6749450628745499\n",
+       "  0.6179790360668559\n",
+       "  0.39303215980893874\n",
+       "  0.29656185967035825\n",
+       "  0.24101053495482927\n",
+       "  0.1606002120357409\n",
+       "  0.5428526100447263\n",
+       "  4.288351484573891\n",
+       " -0.22643018233076517\n",
+       "  4.288351484573884"
       ]
      },
-     "execution_count": 19,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -763,22 +719,21 @@
     {
      "data": {
       "text/plain": [
-       "10-element Array{Float64,1}:\n",
-       "  0.6749450628745901\n",
-       "  0.6179790360668731\n",
-       "  0.39303215980894035\n",
-       "  0.29656185967037274\n",
-       "  0.24101053495484248\n",
-       "  0.1606002120357537\n",
-       "  0.5428526100447416\n",
-       "  4.2883514845739015\n",
-       " -0.22643018233076506\n",
-       "  4.288351484573905"
+       "10-element Vector{Float64}:\n",
+       "  0.6749450628745521\n",
+       "  0.6179790360668558\n",
+       "  0.3930321598089389\n",
+       "  0.29656185967035864\n",
+       "  0.24101053495482938\n",
+       "  0.16060021203574099\n",
+       "  0.5428526100447264\n",
+       "  4.288351484573887\n",
+       " -0.22643018233076218\n",
+       "  4.2883514845738775"
       ]
      },
-     "execution_count": 20,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -787,7 +742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -795,15 +750,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.4.2",
+   "display_name": "Julia 1.7.1",
    "language": "julia",
-   "name": "julia-1.4"
+   "name": "julia-1.7"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.4.2"
+   "version": "1.7.1"
   }
  },
  "nbformat": 4,

--- a/examples/04_managing_log_output.ipynb
+++ b/examples/04_managing_log_output.ipynb
@@ -44,7 +44,75 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1779 rows, 1627 cols, 56716 nonzeros\n",
+      "1779 rows, 1627 cols, 56716 nonzeros\n",
+      "\n",
+      "Solving MIP model with:\n",
+      "   1779 rows\n",
+      "   1627 cols (29 binary, 0 integer, 0 implied int., 1598 continuous)\n",
+      "   56716 nonzeros\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     13      1616     0.1s\n",
+      "         0       0         0   0.00%   0               inf                  inf     3942     12     99     30330    14.6s\n",
+      " T      15       0         3   1.61%   0               0.0498354344     100.00%     3951     12    109     39558    16.3s\n",
+      " T      27       1        10   3.42%   0               0.0474230913     100.00%     3974     12    131     45590    17.4s\n",
+      " T      45       4        20  77.27%   0.0381825316    0.0460846816      17.15%     4563     15    162     58011    20.1s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.0460846815889\n",
+      "  Dual bound        0.0460846815889\n",
+      "  Gap               0% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.0460846815889 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    0 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            21.37 (total)\n",
+      "                    0.02 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             53\n",
+      "  LP iterations     60163 (total)\n",
+      "                    19015 (strong br.)\n",
+      "                    707 (separation)\n",
+      "                    28049 (heuristics)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Dict{Any, Any} with 11 entries:\n",
+       "  :TargetIndexes      => [10]\n",
+       "  :SolveTime          => 21.369\n",
+       "  :TotalTime          => 39.5667\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[785] _[786] … _[811] _[812];;; _[813] _[814] … _[83…\n",
+       "  :TighteningApproach => \"lp\"\n",
+       "  :PerturbationFamily => linf-norm-bounded-0.05\n",
+       "  :SolveStatus        => OPTIMAL\n",
+       "  :Model              => A JuMP Model…\n",
+       "  :Output             => JuMP.AffExpr[-0.012063867412507534 _[1601] + 0.6606525…\n",
+       "  :PredictedIndex     => 8"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "MIPVerify.find_adversarial_example(\n",
     "    n1, \n",
@@ -67,9 +135,84 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m[debug | Memento]: Logger(root) is already registered and force=false.\u001b[39m\n",
+      "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
+      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
+      "\u001b[32m[info | MIPVerify]: Applying Flatten() ... \u001b[39m\n",
+      "\u001b[32m[info | MIPVerify]: Applying Linear(784 -> 40) ... \u001b[39m\n",
+      "\u001b[32m[info | MIPVerify]: Applying ReLU() ...\u001b[39m\n",
+      "\u001b[32m[info | MIPVerify]: Applying Linear(40 -> 20) ... \u001b[39m\n",
+      "\u001b[32m[info | MIPVerify]: Applying ReLU() ...\u001b[39m\n",
+      "\u001b[32m[info | MIPVerify]: Applying Linear(20 -> 10) ... \u001b[39m\n",
+      "Running HiGHS 1.4.2 [date: 1970-01-01, git hash: f797c1ab6]\n",
+      "Copyright (c) 2022 ERGO-Code under MIT licence terms\n",
+      "Presolving model\n",
+      "1779 rows, 1627 cols, 56716 nonzeros\n",
+      "1779 rows, 1627 cols, 56716 nonzeros\n",
+      "\n",
+      "Solving MIP model with:\n",
+      "   1779 rows\n",
+      "   1627 cols (29 binary, 0 integer, 0 implied int., 1598 continuous)\n",
+      "   56716 nonzeros\n",
+      "\n",
+      "        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n",
+      "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n",
+      "\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0      0         0     0.0s\n",
+      "         0       0         0   0.00%   0               inf                  inf        0      0     13      1616     0.1s\n",
+      "         0       0         0   0.00%   0               inf                  inf     3942     12     99     30330    14.3s\n",
+      " T      15       0         3   1.61%   0               0.0498354344     100.00%     3951     12    109     39558    16.1s\n",
+      " T      27       1        10   3.42%   0               0.0474230913     100.00%     3974     12    131     45590    17.1s\n",
+      " T      45       4        20  77.27%   0.0381825316    0.0460846816      17.15%     4563     15    162     58011    20.2s\n",
+      "\n",
+      "Solving report\n",
+      "  Status            Optimal\n",
+      "  Primal bound      0.0460846815889\n",
+      "  Dual bound        0.0460846815889\n",
+      "  Gap               0% (tolerance: 0.01%)\n",
+      "  Solution status   feasible\n",
+      "                    0.0460846815889 (objective)\n",
+      "                    0 (bound viol.)\n",
+      "                    0 (int. viol.)\n",
+      "                    0 (row viol.)\n",
+      "  Timing            21.52 (total)\n",
+      "                    0.02 (presolve)\n",
+      "                    0.00 (postsolve)\n",
+      "  Nodes             53\n",
+      "  LP iterations     60163 (total)\n",
+      "                    19015 (strong br.)\n",
+      "                    707 (separation)\n",
+      "                    28049 (heuristics)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Dict{Any, Any} with 11 entries:\n",
+       "  :TargetIndexes      => [10]\n",
+       "  :SolveTime          => 21.5182\n",
+       "  :TotalTime          => 22.2792\n",
+       "  :Perturbation       => [_[1] _[2] … _[27] _[28];;; _[29] _[30] … _[55] _[56];…\n",
+       "  :PerturbedInput     => [_[785] _[786] … _[811] _[812];;; _[813] _[814] … _[83…\n",
+       "  :TighteningApproach => \"lp\"\n",
+       "  :PerturbationFamily => linf-norm-bounded-0.05\n",
+       "  :SolveStatus        => OPTIMAL\n",
+       "  :Model              => A JuMP Model…\n",
+       "  :Output             => JuMP.AffExpr[-0.012063867412507534 _[1601] + 0.6606525…\n",
+       "  :PredictedIndex     => 8"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "MIPVerify.set_log_level!(\"debug\")\n",
     "\n",
@@ -96,16 +239,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Memento.Logger"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "typeof(MIPVerify.LOGGER)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/04_managing_log_output.ipynb
+++ b/examples/04_managing_log_output.ipynb
@@ -16,48 +16,18 @@
    "outputs": [],
    "source": [
     "using MIPVerify\n",
-    "using Gurobi"
+    "using HiGHS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1×28×28×1 Array{Float64,4}:\n",
-       "[:, :, 1, 1] =\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       "\n",
-       "[:, :, 2, 1] =\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       "\n",
-       "[:, :, 3, 1] =\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       "\n",
-       "...\n",
-       "\n",
-       "[:, :, 26, 1] =\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       "\n",
-       "[:, :, 27, 1] =\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       "\n",
-       "[:, :, 28, 1] =\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "mnist = MIPVerify.read_datasets(\"MNIST\")\n",
-    "n1 = MIPVerify.get_example_network_params(\"MNIST.WK17a_linf0.1_authors\")\n",
-    "sample_image = MIPVerify.get_image(mnist.test.images, 1)"
+    "n1 = MIPVerify.get_example_network_params(\"MNIST.n1\")\n",
+    "sample_image = MIPVerify.get_image(mnist.test.images, 1);"
    ]
   },
   {
@@ -74,96 +44,14 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:01\u001b[39m\n",
-      "\u001b[32m  Calculating upper bounds:   1%|▏                      |  ETA: 0:47:34\u001b[39m"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:21\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating upper bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Calculating lower bounds: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n",
-      "\u001b[32m  Imposing relu constraint: 100%|███████████████████████| Time: 0:00:00\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
-       "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 0.00462294\n",
-       "  :TotalTime          => 50.902\n",
-       "  :Perturbation       => JuMP.VariableRef[noname noname … noname noname]…\n",
-       "  :PerturbedInput     => JuMP.VariableRef[noname noname … noname noname]…\n",
-       "  :TighteningApproach => \"lp\"\n",
-       "  :PerturbationFamily => linf-norm-bounded-0.05\n",
-       "  :SolveStatus        => INFEASIBLE_OR_UNBOUNDED\n",
-       "  :Model              => A JuMP Model…\n",
-       "  :Output             => JuMP.GenericAffExpr{Float64,JuMP.VariableRef}[0.000383…\n",
-       "  :PredictedIndex     => 8"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "MIPVerify.find_adversarial_example(\n",
     "    n1, \n",
     "    sample_image, \n",
     "    10, \n",
-    "    Gurobi.Optimizer,\n",
-    "    # OutputFlag=0 prevents any output from being printed out\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(),\n",
     "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.05),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
@@ -179,53 +67,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[34m[debug | Memento]: Logger(root) is already registered.\u001b[39m\n",
-      "Academic license - for non-commercial use only\n",
-      "\u001b[36m[notice | MIPVerify]: Attempting to find adversarial example. Neural net predicted label is 8, target labels are [10]\u001b[39m\n",
-      "\u001b[36m[notice | MIPVerify]: Determining upper and lower bounds for the input to each non-linear unit.\u001b[39m\n",
-      "Academic license - for non-commercial use only\n",
-      "\u001b[32m[info | MIPVerify]: Applying Conv2d(1, 16, kernel_size=(4, 4), stride=(2, 2), padding=same) ... \u001b[39m\n",
-      "\u001b[32m[info | MIPVerify]: Applying ReLU() ...\u001b[39m\n",
-      "\u001b[32m[info | MIPVerify]: Applying Conv2d(16, 32, kernel_size=(4, 4), stride=(2, 2), padding=same) ... \u001b[39m\n",
-      "\u001b[32m[info | MIPVerify]: Applying ReLU() ...\u001b[39m\n",
-      "Academic license - for non-commercial use only\n",
-      "\u001b[32m[info | MIPVerify]: Applying Flatten() ... \u001b[39m\n",
-      "\u001b[32m[info | MIPVerify]: Applying Linear(1568 -> 100) ... \u001b[39m\n",
-      "\u001b[32m[info | MIPVerify]: Applying ReLU() ...\u001b[39m\n",
-      "\u001b[32m[info | MIPVerify]: Applying Linear(100 -> 10) ... \u001b[39m\n",
-      "Academic license - for non-commercial use only\n",
-      "Academic license - for non-commercial use only\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Dict{Any,Any} with 11 entries:\n",
-       "  :TargetIndexes      => [10]\n",
-       "  :SolveTime          => 0.00461507\n",
-       "  :TotalTime          => 4.68894\n",
-       "  :Perturbation       => JuMP.VariableRef[noname noname … noname noname]…\n",
-       "  :PerturbedInput     => JuMP.VariableRef[noname noname … noname noname]…\n",
-       "  :TighteningApproach => \"lp\"\n",
-       "  :PerturbationFamily => linf-norm-bounded-0.05\n",
-       "  :SolveStatus        => INFEASIBLE_OR_UNBOUNDED\n",
-       "  :Model              => A JuMP Model…\n",
-       "  :Output             => JuMP.GenericAffExpr{Float64,JuMP.VariableRef}[0.000383…\n",
-       "  :PredictedIndex     => 8"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "MIPVerify.set_log_level!(\"debug\")\n",
     "\n",
@@ -233,9 +77,8 @@
     "    n1, \n",
     "    sample_image, \n",
     "    10, \n",
-    "    Gurobi.Optimizer,\n",
-    "    # OutputFlag=0 prevents any output from being printed out\n",
-    "    Dict(\"OutputFlag\" => 0),\n",
+    "    HiGHS.Optimizer,\n",
+    "    Dict(),\n",
     "    pp = MIPVerify.LInfNormBoundedPerturbationFamily(0.05),\n",
     "    norm_order = Inf,\n",
     "    tightening_algorithm = lp,\n",
@@ -253,20 +96,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Memento.Logger"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "typeof(MIPVerify.LOGGER)"
    ]
@@ -281,15 +113,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.4.2",
+   "display_name": "Julia 1.7.1",
    "language": "julia",
-   "name": "julia-1.4"
+   "name": "julia-1.7"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.4.2"
+   "version": "1.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Switch from Gurobi to HiGHS to enable repro without having a Gurobi license.
- Remove L2-norm example as HiGHS does not appear to support MIQP