### PR TITLE
Move data source for MIPVerify_data.

### DIFF
--- a/examples/01_importing_your_own_neural_net.ipynb
+++ b/examples/01_importing_your_own_neural_net.ipynb
@@ -73,7 +73,7 @@
     }
    ],
    "source": [
-    "param_dict = Base.download(\"https://github.com/vtjeng/MIPVerify_data/raw/master/weights/mnist/n1.mat\") |> matread"
+    "param_dict = Base.download(\"https://storage.googleapis.com/mipverify-data/weights/mnist/n1.mat\") |> matread"
    ]
   },
   {

--- a/src/utils/prep_data_file.jl
+++ b/src/utils/prep_data_file.jl
@@ -1,6 +1,6 @@
 using Downloads
 
-const data_repo_path = "https://github.com/vtjeng/MIPVerify_data/raw/master"
+const data_repo_path = "https://storage.googleapis.com/mipverify-data"
 
 function prep_data_file(relative_dir::String, filename::String)::String
     absolute_dir = joinpath(dependencies_path, relative_dir)


### PR DESCRIPTION
I manually uploaded the files currently at http://github.com/vtjeng/MIPVerify_data to the relevant GCP bucket.

This allows us to reduce spend on Git LFS and get more reliably behavior.
