### PR TITLE
Fix URL for documentation.

### DIFF
--- a/examples/01_importing_your_own_neural_net.ipynb
+++ b/examples/01_importing_your_own_neural_net.ipynb
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`get_matrix_params` requires that 1) you specify the expected size of the layer, and 2) your weight and bias arrays following the naming convention outlined in the [documentation](https://vtjeng.com/MIPVerify.jl/stable/utils/import_weights/#MIPVerify.get_matrix_params-Tuple{Dict{String},%20String,%20Tuple{Int64,%20Int64}})."
+    "`get_matrix_params` requires that 1) you specify the expected size of the layer, and 2) your weight and bias arrays following the naming convention outlined in the [documentation](https://vtjeng.github.io/MIPVerify.jl/stable/utils/import_weights/#MIPVerify.get_matrix_params-Tuple{Dict{String},%20String,%20Tuple{Int64,%20Int64}})."
    ]
   },
   {

--- a/examples/02_finding_adversarial_examples_in_depth.ipynb
+++ b/examples/02_finding_adversarial_examples_in_depth.ipynb
@@ -72,7 +72,7 @@
     "solve_if_predicted_in_targeted = true\n",
     "```\n",
     "\n",
-    "See [full documentation here](https://vtjeng.com/MIPVerify.jl/dev/finding_adversarial_examples/single_image/#MIPVerify.find_adversarial_example-Tuple{NeuralNet,%20Array{%3C:Real},%20Union{Integer,%20Vector{%3C:Integer}},%20Any,%20Dict}).\n",
+    "See [full documentation here](https://vtjeng.github.io/MIPVerify.jl/dev/finding_adversarial_examples/single_image/#MIPVerify.find_adversarial_example-Tuple{NeuralNet,%20Array{%3C:Real},%20Union{Integer,%20Vector{%3C:Integer}},%20Any,%20Dict}).\n",
     "\n",
     "We explore what some of these options allow us to do."
    ]


### PR DESCRIPTION
Rather than using the custom site vtjeng.com, we use vtjeng.github.io, which will be stable going forward.