### PR TITLE
Certify LP tightening bounds and instrument verification runs

### DIFF
--- a/benchmarks/summarize_wk17a_pair.jl
+++ b/benchmarks/summarize_wk17a_pair.jl
@@ -1,0 +1,121 @@
+# Compares two benchmark_wk17a_first100.jl output directories sample-by-sample.
+#
+# Usage:
+#   julia --project=benchmarks benchmarks/summarize_wk17a_pair.jl \
+#       --baseline /path/to/baseline-out --candidate /path/to/candidate-out
+#
+# Reports aggregate deltas, per-sample time distributions (including build+tightening
+# time, where certification cost lives), semantic-outcome and solve-status changes,
+# and objective-value agreement over commonly solved samples.
+
+using CSV
+using DataFrames
+using Statistics
+
+function parse_args(args::Vector{String})::Dict{String,String}
+    parsed = Dict{String,String}()
+    i = 1
+    while i <= length(args)
+        startswith(args[i], "--") || error("Unexpected argument $(args[i])")
+        i + 1 <= length(args) || error("Missing value for $(args[i])")
+        parsed[args[i][3:end]] = args[i+1]
+        i += 2
+    end
+    return parsed
+end
+
+function print_distribution(name::String, base::Vector{Float64}, cand::Vector{Float64})
+    for (stat, f) in (
+        ("mean", mean),
+        ("median", median),
+        ("p90", v -> quantile(v, 0.9)),
+        ("p99", v -> quantile(v, 0.99)),
+        ("max", maximum),
+    )
+        base_value = f(base)
+        cand_value = f(cand)
+        delta = base_value == 0 ? NaN : (cand_value - base_value) / base_value * 100
+        println(
+            "$(name)_$(stat)_seconds,$(round(base_value; digits = 3))," *
+            "$(round(cand_value; digits = 3)),$(round(delta; digits = 2))%",
+        )
+    end
+end
+
+function main()
+    options = parse_args(ARGS)
+    baseline_dir = options["baseline"]
+    candidate_dir = options["candidate"]
+
+    base = CSV.read(joinpath(baseline_dir, "benchmark_per_sample.csv"), DataFrame)
+    cand = CSV.read(joinpath(candidate_dir, "benchmark_per_sample.csv"), DataFrame)
+    base_metrics = CSV.read(joinpath(baseline_dir, "benchmark_metrics.csv"), DataFrame)
+    cand_metrics = CSV.read(joinpath(candidate_dir, "benchmark_metrics.csv"), DataFrame)
+
+    println("metric,baseline,candidate,delta")
+    for column in (:wall_clock_seconds, :sum_total_time_seconds, :sum_solve_time_seconds)
+        base_value = Float64(base_metrics[1, column])
+        cand_value = Float64(cand_metrics[1, column])
+        delta = round((cand_value - base_value) / base_value * 100; digits = 2)
+        println(
+            "$(column),$(round(base_value; digits = 3))," *
+            "$(round(cand_value; digits = 3)),$(delta)%",
+        )
+    end
+
+    print_distribution(
+        "total_time",
+        Float64.(base.total_time_seconds),
+        Float64.(cand.total_time_seconds),
+    )
+    print_distribution(
+        "solve_time",
+        Float64.(base.solve_time_seconds),
+        Float64.(cand.solve_time_seconds),
+    )
+    print_distribution(
+        "build_and_tightening_time",
+        Float64.(base.total_time_seconds .- base.solve_time_seconds),
+        Float64.(cand.total_time_seconds .- cand.solve_time_seconds),
+    )
+
+    joined = innerjoin(base, cand; on = :sample_index, renamecols = "_baseline" => "_candidate")
+    println("samples_joined,$(nrow(joined))")
+
+    outcome_changed =
+        filter(r -> r.semantic_outcome_baseline != r.semantic_outcome_candidate, joined)
+    println("semantic_outcome_changes,$(nrow(outcome_changed))")
+    for r in eachrow(first(outcome_changed, 20))
+        println(
+            "  sample $(r.sample_index): " *
+            "$(r.semantic_outcome_baseline) -> $(r.semantic_outcome_candidate)",
+        )
+    end
+
+    status_changed = filter(r -> r.solve_status_baseline != r.solve_status_candidate, joined)
+    println("solve_status_changes,$(nrow(status_changed))")
+    for r in eachrow(first(status_changed, 20))
+        println(
+            "  sample $(r.sample_index): " *
+            "$(r.solve_status_baseline) -> $(r.solve_status_candidate)",
+        )
+    end
+
+    solved_both = filter(
+        r -> !ismissing(r.objective_value_baseline) && !ismissing(r.objective_value_candidate),
+        joined,
+    )
+    println("objective_value_comparable_samples,$(nrow(solved_both))")
+    if nrow(solved_both) > 0
+        diffs = abs.(solved_both.objective_value_baseline .- solved_both.objective_value_candidate)
+        println("objective_value_max_abs_diff,$(maximum(diffs))")
+        println("objective_value_mean_abs_diff,$(mean(diffs))")
+        println("objective_value_diff_count_gt_1e-6,$(count(>(1e-6), diffs))")
+    end
+
+    base_hash = string(base_metrics[1, :dependency_snapshot_sha256])
+    cand_hash = string(cand_metrics[1, :dependency_snapshot_sha256])
+    println("dependency_snapshot_match,$(base_hash == cand_hash)")
+end
+
+main()

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -71,17 +71,10 @@ function relax_integrality_context(f, model::Model, should_relax_integrality::Bo
 end
 
 function objective_bound_or_nothing(model::JuMP.Model)
-    value = try
-        JuMP.objective_bound(model)
-    catch error
-        if error isa MathOptInterface.ResultIndexBoundsError ||
-           error isa MathOptInterface.UnsupportedAttribute ||
-           error isa MathOptInterface.GetAttributeNotAllowed
-            return nothing
-        end
-        rethrow()
-    end
-    return value isa Real && isfinite(value) ? value : nothing
+    return solver_attribute_or_nothing(
+        () -> JuMP.objective_bound(model),
+        "the solver objective bound",
+    )
 end
 
 """

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -102,6 +102,13 @@ arithmetic, as a backup.
   certificate is.
 - If we reach the user-defined time limit, return `b_0`.
 - For all other solve statuses, we warn the user and report `b_0`.
+
+Whenever an optimal solution is reported, its objective value is cross-checked against `b_0`.
+The solution is a feasible point of the model, so its value can never lie outside a bound that
+interval arithmetic computed for the same model; if it does (beyond solver feasibility
+tolerances), the solver and our view of the model disagree — solver numerics have failed or the
+model plumbing is desynced — and no bound computed by this run can be trusted, so we raise an
+error rather than continue.
 """
 function tight_bound_helper(
     m::Model,
@@ -114,6 +121,19 @@ function tight_bound_helper(
     optimize!(m)
     status = JuMP.termination_status(m)
     if status == MathOptInterface.OPTIMAL
+        incumbent =
+            solver_attribute_or_nothing(() -> JuMP.objective_value(m), "the solver objective value")
+        if incumbent !== nothing
+            violation = bound_type == lower_bound_type ? b_0 - incumbent : incumbent - b_0
+            if violation > 1e-8 * (1 + abs(b_0))
+                Memento.error(
+                    MIPVerify.LOGGER,
+                    "The solver reported a feasible point with objective value $(incumbent), " *
+                    "outside the interval-arithmetic bound $(b_0). The solver and the model " *
+                    "disagree, so no bound computed by this run can be trusted.",
+                )
+            end
+        end
         if tightening_algorithm == lp
             if !JuMP.has_duals(m)
                 Memento.debug(

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -122,11 +122,23 @@ function tight_bound_helper(
     status = JuMP.termination_status(m)
     if status == MathOptInterface.OPTIMAL
         if tightening_algorithm == lp
-            JuMP.has_duals(m) || return b_0
+            if !JuMP.has_duals(m)
+                Memento.debug(
+                    MIPVerify.LOGGER,
+                    "Using interval-arithmetic bound: LP solver reported no dual solution.",
+                )
+                return b_0
+            end
             return certified_lp_bound(m, bound_type, objective, b_0)
         end
         solver_bound = objective_bound_or_nothing(m)
-        solver_bound === nothing && return b_0
+        if solver_bound === nothing
+            Memento.debug(
+                MIPVerify.LOGGER,
+                "Using interval-arithmetic bound: solver reported no finite objective bound.",
+            )
+            return b_0
+        end
         return bound_type == lower_bound_type ? max(b_0, solver_bound) : min(b_0, solver_bound)
     elseif status == MathOptInterface.TIME_LIMIT
         return b_0
@@ -486,6 +498,12 @@ function maximum_ge(xs::AbstractArray{T})::JuMPLinearType where {T<:JuMPLinearTy
     model = owner_model(xs)
     x_max = @variable(model)
     @constraint(model, x_max .>= xs)
+    # In the standard flow x_max is only created after bound tightening has completed, but
+    # declare the lower bound implied by the constraints above anyway: if a variable with no
+    # finite declared bounds is present in a model during a later `certified_lp_bound` call,
+    # any nonzero stationarity residual on it forces the certificate to be abandoned.
+    implied_lower = maximum(lower_bound.(xs))
+    isfinite(implied_lower) && set_lower_bound(x_max, implied_lower)
     return x_max
 end
 

--- a/src/net_components/core_ops.jl
+++ b/src/net_components/core_ops.jl
@@ -43,15 +43,13 @@ bound_obj = Dict(
     lower_bound_type => MathOptInterface.MIN_SENSE,
     upper_bound_type => MathOptInterface.MAX_SENSE
 )
-bound_delta_f = Dict(
-    lower_bound_type => (b, b_0) -> b - b_0,
-    upper_bound_type => (b, b_0) -> b_0 - b
-)
 bound_operator = Dict(
     lower_bound_type => >=,
     upper_bound_type => <=
 )
 #! format: on
+
+include("lp_certification.jl")
 
 """
 $(SIGNATURES)
@@ -60,14 +58,30 @@ Context manager for running `f` on `model`. If `should_relax_integrality` is tru
 integrality constraints are relaxed before `f` is run and re-imposed after.
 """
 function relax_integrality_context(f, model::Model, should_relax_integrality::Bool)
-    if should_relax_integrality
-        undo_relax = relax_integrality(model)
+    if !should_relax_integrality
+        return f(model)
     end
-    r = f(model)
-    if should_relax_integrality
+
+    undo_relax = relax_integrality(model)
+    try
+        return f(model)
+    finally
         undo_relax()
     end
-    return r
+end
+
+function objective_bound_or_nothing(model::JuMP.Model)
+    value = try
+        JuMP.objective_bound(model)
+    catch error
+        if error isa MathOptInterface.ResultIndexBoundsError ||
+           error isa MathOptInterface.UnsupportedAttribute ||
+           error isa MathOptInterface.GetAttributeNotAllowed
+            return nothing
+        end
+        rethrow()
+    end
+    return value isa Real && isfinite(value) ? value : nothing
 end
 
 """
@@ -76,28 +90,44 @@ $(SIGNATURES)
 Optimizes the value of `objective` based on `bound_type`, with `b_0`, computed via interval
 arithmetic, as a backup.
 
-- If an optimal solution is reached, we return the objective value. We also verify that the 
-  objective found is better than the bound `b_0` provided; if this is not the case, we throw an
-  error.
-- If we reach the user-defined time limit, we compute the best objective bound found. We compare 
-  this to `b_0` and return the better result.
+- If an optimal LP solution is reached and row duals are available, validate them and return the
+  resulting certified Lagrangian bound. The certificate is re-verified here with outward
+  rounding, so its validity does not depend on the solver's duals being exactly feasible.
+  Otherwise, return `b_0`.
+- If an optimal MIP solution is reached, return the solver's objective bound (its dual bound).
+  In exact arithmetic, weak duality places the objective bound on the valid side of the true
+  optimum, overshooting it by at most the achieved gap (objective bound minus incumbent
+  objective value), and OPTIMAL termination keeps that gap within the solver's gap tolerance.
+  The incumbent objective value can sit on the invalid side by up to the same gap, which is why
+  it is not used here. Two claims are trusted rather than verified: (1) the reported bound is
+  assembled from floating-point node relaxation bounds without directed rounding, so its
+  validity is subject to the solver's numerics; (2) the incumbent is feasible only up to the
+  solver's feasibility and integrality tolerances, so the true conservatism can exceed the
+  reported gap by a tolerance-scale amount (this weakens the tightness claim, but a
+  super-optimal incumbent cannot invalidate the bound). Solvers expose no independently
+  checkable MIP certificate through JuMP, so neither claim can be re-verified the way the LP
+  certificate is.
+- If we reach the user-defined time limit, return `b_0`.
 - For all other solve statuses, we warn the user and report `b_0`.
 """
-function tight_bound_helper(m::Model, bound_type::BoundType, objective::JuMPLinearType, b_0::Number)
+function tight_bound_helper(
+    m::Model,
+    bound_type::BoundType,
+    objective::JuMPLinearType,
+    b_0::Number,
+    tightening_algorithm::TighteningAlgorithm,
+)
     @objective(m, bound_obj[bound_type], objective)
     optimize!(m)
     status = JuMP.termination_status(m)
     if status == MathOptInterface.OPTIMAL
-        b = JuMP.objective_value(m)
-        db = bound_delta_f[bound_type](b, b_0)
-        if db < -1e-8
-            Memento.warn(MIPVerify.LOGGER, "Δb = $(db)")
-            Memento.error(
-                MIPVerify.LOGGER,
-                "Δb = $(db). Tightening via interval arithmetic should not give a better result than an optimal optimization.",
-            )
+        if tightening_algorithm == lp
+            JuMP.has_duals(m) || return b_0
+            return certified_lp_bound(m, bound_type, objective, b_0)
         end
-        return b
+        solver_bound = objective_bound_or_nothing(m)
+        solver_bound === nothing && return b_0
+        return bound_type == lower_bound_type ? max(b_0, solver_bound) : min(b_0, solver_bound)
     elseif status == MathOptInterface.TIME_LIMIT
         return b_0
     else
@@ -132,7 +162,7 @@ function tight_bound(
     should_relax_integrality = (tightening_algorithm == lp)
     # x is not constant, and thus x must have an associated model
     bound_value = return relax_integrality_context(owner_model(x), should_relax_integrality) do m
-        tight_bound_helper(m, bound_type, x, b_0)
+        tight_bound_helper(m, bound_type, x, b_0, tightening_algorithm)
     end
 
     return bound_value

--- a/src/net_components/lp_certification.jl
+++ b/src/net_components/lp_certification.jl
@@ -1,6 +1,7 @@
+const ZERO_INTERVAL = IntervalArithmetic.interval(0.0)
+
 function add_interval_coefficient!(coefficients, variable::JuMP.VariableRef, delta)
-    zero_interval = IntervalArithmetic.interval(0.0)
-    coefficients[variable] = get(coefficients, variable, zero_interval) + delta
+    coefficients[variable] = get(coefficients, variable, ZERO_INTERVAL) + delta
     return nothing
 end
 
@@ -95,9 +96,7 @@ function certified_lp_bound(
     interval_bound::Real;
     dual_value = JuMP.dual,
 )::Real
-    zero_interval = IntervalArithmetic.interval(0.0)
-    interval_type = typeof(zero_interval)
-    coefficients = Dict{JuMP.VariableRef,interval_type}()
+    coefficients = Dict{JuMP.VariableRef,typeof(ZERO_INTERVAL)}()
     objective_affine = convert(JuMP.AffExpr, objective)
     objective_multiplier = bound_type == lower_bound_type ? 1.0 : -1.0
     certificate =

--- a/src/net_components/lp_certification.jl
+++ b/src/net_components/lp_certification.jl
@@ -119,11 +119,32 @@ function certified_lp_bound(
     for (variable, coefficient) in coefficients
         IntervalArithmetic.isthinzero(coefficient) && continue
         variable_interval = variable_interval_or_nothing(variable)
-        variable_interval === nothing && return interval_bound
-        certificate += coefficient * variable_interval
+        if variable_interval === nothing
+            Memento.debug(
+                MIPVerify.LOGGER,
+                "Using interval-arithmetic bound: $(variable) has an invalid declared interval.",
+            )
+            return interval_bound
+        end
+        term = coefficient * variable_interval
+        if !isfinite(lower_bound(term))
+            Memento.debug(
+                MIPVerify.LOGGER,
+                "Using interval-arithmetic bound: $(variable) has a nonzero stationarity " *
+                "residual but no finite declared bound to absorb it.",
+            )
+            return interval_bound
+        end
+        certificate += term
     end
     transformed_lower = lower_bound(certificate)
-    isfinite(transformed_lower) || return interval_bound
+    if !isfinite(transformed_lower)
+        Memento.debug(
+            MIPVerify.LOGGER,
+            "Using interval-arithmetic bound: the certificate value is not finite.",
+        )
+        return interval_bound
+    end
     candidate = bound_type == lower_bound_type ? transformed_lower : -transformed_lower
     if bound_type == lower_bound_type
         return max(interval_bound, candidate)

--- a/src/net_components/lp_certification.jl
+++ b/src/net_components/lp_certification.jl
@@ -1,0 +1,132 @@
+function add_interval_coefficient!(coefficients, variable::JuMP.VariableRef, delta)
+    zero_interval = IntervalArithmetic.interval(0.0)
+    coefficients[variable] = get(coefficients, variable, zero_interval) + delta
+    return nothing
+end
+
+function projected_dual_and_reference(set::MathOptInterface.LessThan, dual_value::Real)
+    return (min(dual_value, 0.0), set.upper)
+end
+
+function projected_dual_and_reference(set::MathOptInterface.GreaterThan, dual_value::Real)
+    return (max(dual_value, 0.0), set.lower)
+end
+
+function projected_dual_and_reference(set::MathOptInterface.EqualTo, dual_value::Real)
+    return (dual_value, set.value)
+end
+
+function projected_dual_and_reference(set::MathOptInterface.Interval, dual_value::Real)
+    reference = dual_value >= 0 ? set.lower : set.upper
+    return (dual_value, reference)
+end
+
+projected_dual_and_reference(::MathOptInterface.AbstractScalarSet, ::Real) = nothing
+
+function constraint_dual_or_nothing(constraint, dual_value)
+    value = try
+        dual_value(constraint)
+    catch error
+        if error isa MathOptInterface.ResultIndexBoundsError ||
+           error isa MathOptInterface.UnsupportedAttribute ||
+           error isa MathOptInterface.GetAttributeNotAllowed
+            return nothing
+        end
+        rethrow()
+    end
+    return value isa Real && isfinite(value) ? value : nothing
+end
+
+function variable_interval_or_nothing(variable::JuMP.VariableRef)
+    if JuMP.is_fixed(variable)
+        value = JuMP.fix_value(variable)
+        return isfinite(value) ? IntervalArithmetic.interval(value) : nothing
+    end
+    lower = JuMP.has_lower_bound(variable) ? JuMP.lower_bound(variable) : -Inf
+    upper = JuMP.has_upper_bound(variable) ? JuMP.upper_bound(variable) : Inf
+    if JuMP.is_binary(variable)
+        lower = max(lower, 0.0)
+        upper = min(upper, 1.0)
+    end
+    if isnan(lower) || isnan(upper) || lower > upper
+        return nothing
+    end
+    return IntervalArithmetic.interval(lower, upper)
+end
+
+"""
+    certified_lp_bound(model, bound_type, objective, interval_bound; dual_value = JuMP.dual)
+
+Return an LP bound certified from row duals and the declared variable bounds.
+
+The row duals are treated as candidate Lagrange multipliers. Their signs are projected onto the
+dual cones, and any stationarity residual is minimized over the variables' interval bounds. All
+certificate arithmetic is outward-rounded. Unsupported constraints and unavailable duals use a
+zero multiplier. If the certificate is unbounded or unavailable, return `interval_bound`.
+"""
+function certified_lp_bound(
+    model::JuMP.Model,
+    bound_type::BoundType,
+    objective::JuMPLinearType,
+    interval_bound::Real;
+    dual_value = JuMP.dual,
+)::Real
+    zero_interval = IntervalArithmetic.interval(0.0)
+    interval_type = typeof(zero_interval)
+    coefficients = Dict{JuMP.VariableRef,interval_type}()
+    objective_affine = convert(JuMP.AffExpr, objective)
+    objective_multiplier = bound_type == lower_bound_type ? 1.0 : -1.0
+    certificate =
+        IntervalArithmetic.interval(objective_multiplier) *
+        IntervalArithmetic.interval(objective_affine.constant)
+    for (variable, coefficient) in objective_affine.terms
+        add_interval_coefficient!(
+            coefficients,
+            variable,
+            IntervalArithmetic.interval(objective_multiplier) *
+            IntervalArithmetic.interval(coefficient),
+        )
+    end
+
+    for (function_type, set_type) in JuMP.list_of_constraint_types(model)
+        function_type == JuMP.AffExpr || continue
+        for constraint in JuMP.all_constraints(model, function_type, set_type)
+            row_dual = constraint_dual_or_nothing(constraint, dual_value)
+            row_dual === nothing && continue
+            iszero(row_dual) && continue
+            constraint_object = JuMP.constraint_object(constraint)
+            projected = projected_dual_and_reference(constraint_object.set, row_dual)
+            projected === nothing && continue
+            multiplier, reference = projected
+            (iszero(multiplier) || !isfinite(reference)) && continue
+            multiplier_interval = IntervalArithmetic.interval(multiplier)
+            function_value = constraint_object.func
+            certificate +=
+                multiplier_interval * (
+                    IntervalArithmetic.interval(reference) -
+                    IntervalArithmetic.interval(function_value.constant)
+                )
+            for (variable, coefficient) in function_value.terms
+                add_interval_coefficient!(
+                    coefficients,
+                    variable,
+                    -multiplier_interval * IntervalArithmetic.interval(coefficient),
+                )
+            end
+        end
+    end
+
+    for (variable, coefficient) in coefficients
+        IntervalArithmetic.isthinzero(coefficient) && continue
+        variable_interval = variable_interval_or_nothing(variable)
+        variable_interval === nothing && return interval_bound
+        certificate += coefficient * variable_interval
+    end
+    transformed_lower = lower_bound(certificate)
+    isfinite(transformed_lower) || return interval_bound
+    candidate = bound_type == lower_bound_type ? transformed_lower : -transformed_lower
+    if bound_type == lower_bound_type
+        return max(interval_bound, candidate)
+    end
+    return min(interval_bound, candidate)
+end

--- a/src/net_components/lp_certification.jl
+++ b/src/net_components/lp_certification.jl
@@ -23,18 +23,42 @@ end
 
 projected_dual_and_reference(::MathOptInterface.AbstractScalarSet, ::Real) = nothing
 
-function constraint_dual_or_nothing(constraint, dual_value)
+"""
+    solver_attribute_or_nothing(f, description)
+
+Run `f` and return its result if it is a finite `Real`, and `nothing` otherwise.
+
+Reading an optional solver attribute (a row dual, an objective bound) can tighten a bound but
+is never required for soundness, so the caller always has a valid fallback. The three MOI
+errors that signal an unavailable attribute are expected and return `nothing` quietly. Any
+other error is logged at warn level and also returns `nothing`, so one failed read degrades a
+single bound instead of crashing the run; interrupts and resource exhaustion still propagate.
+"""
+function solver_attribute_or_nothing(f, description::AbstractString)
     value = try
-        dual_value(constraint)
+        f()
     catch error
-        if error isa MathOptInterface.ResultIndexBoundsError ||
-           error isa MathOptInterface.UnsupportedAttribute ||
-           error isa MathOptInterface.GetAttributeNotAllowed
-            return nothing
+        if error isa InterruptException || error isa OutOfMemoryError || error isa StackOverflowError
+            rethrow()
         end
-        rethrow()
+        if !(
+            error isa MathOptInterface.ResultIndexBoundsError ||
+            error isa MathOptInterface.UnsupportedAttribute ||
+            error isa MathOptInterface.GetAttributeNotAllowed
+        )
+            Memento.warn(
+                MIPVerify.LOGGER,
+                "Unexpected error reading $(description); treating it as unavailable: " *
+                sprint(showerror, error),
+            )
+        end
+        return nothing
     end
     return value isa Real && isfinite(value) ? value : nothing
+end
+
+function constraint_dual_or_nothing(constraint, dual_value)
+    return solver_attribute_or_nothing(() -> dual_value(constraint), "a constraint dual")
 end
 
 function variable_interval_or_nothing(variable::JuMP.VariableRef)

--- a/test/net_components.jl
+++ b/test/net_components.jl
@@ -2,6 +2,7 @@ using Test
 @isdefined(TestHelpers) || include("TestHelpers.jl")
 
 TestHelpers.@timed_testset "net_components/" begin
+    include("net_components/lp_certification.jl")
     include("net_components/core_ops.jl")
     include("net_components/layers.jl")
     include("net_components/nets.jl")

--- a/test/net_components/core_ops.jl
+++ b/test/net_components/core_ops.jl
@@ -92,6 +92,18 @@ TestHelpers.@timed_testset "core_ops.jl" begin
         end
     end
 
+    @testset "relax_integrality_context restores integrality after errors" begin
+        m = TestHelpers.get_new_model()
+        @variable(m, x, Bin)
+
+        @test_throws ErrorException MIPVerify.relax_integrality_context(m, true) do model
+            @test count_binary_variables(model) == 0
+            error("test error")
+        end
+
+        @test count_binary_variables(m) == 1
+    end
+
     @testset "maximum(xs)" begin
         @testset "single variable to maximize over" begin
             m = TestHelpers.get_new_model()
@@ -613,8 +625,15 @@ TestHelpers.@timed_testset "core_ops.jl" begin
                     m.ext[:MIPVerify] = MIPVerify.MIPVerifyExt(algorithm)
                     output = (x |> p1 |> ReLU() |> p2)
 
-                    @test tight_upperbound(output[1], nta = algorithm) ≈ u
-                    @test tight_lowerbound(output[2], nta = algorithm) ≈ l
+                    ub = tight_upperbound(output[1], nta = algorithm)
+                    lb = tight_lowerbound(output[2], nta = algorithm)
+                    # Computed bounds must never be tighter than the true extremum
+                    # (modulo solver numerics), but are only guaranteed to match it
+                    # up to solver tolerances: mip returns the solver's dual bound,
+                    # within the MIP gap tolerance (default 1e-4 relative) of the
+                    # optimum, and lp rounds the certified bound outward.
+                    @test u - 1e-6 <= ub <= u + abs(u) * 1e-3
+                    @test l - abs(l) * 1e-3 <= lb <= l + 1e-6
                 end
             end
         end

--- a/test/net_components/lp_certification.jl
+++ b/test/net_components/lp_certification.jl
@@ -6,14 +6,17 @@ using MathOptInterface: MathOptInterface
 using MIPVerify:
     MIPVerifyExt,
     certified_lp_bound,
+    constraint_dual_or_nothing,
     lower_bound,
     lower_bound_type,
     lp,
     mip,
+    projected_dual_and_reference,
     tight_lowerbound,
     tight_upperbound,
     upper_bound,
-    upper_bound_type
+    upper_bound_type,
+    variable_interval_or_nothing
 
 @isdefined(TestHelpers) || include("../TestHelpers.jl")
 
@@ -367,5 +370,90 @@ TestHelpers.@timed_testset "lp_certification.jl" begin
         @constraint(m_lower, y >= -1)
 
         @test tight_lowerbound(y; nta = mip) == -1.0
+    end
+
+    @testset "falls back when the MIP objective bound is not finite" begin
+        mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_objective_value = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            mock,
+            optimizer -> begin
+                MathOptInterface.Utilities.mock_optimize!(optimizer, MathOptInterface.OPTIMAL, [0.999])
+                MathOptInterface.set(optimizer, MathOptInterface.ObjectiveValue(), 0.999)
+                MathOptInterface.set(optimizer, MathOptInterface.ObjectiveBound(), Inf)
+            end,
+        )
+        m = Model(() -> mock)
+        m.ext[:MIPVerify] = MIPVerifyExt(mip)
+        @variable(m, 0 <= x <= 2)
+        @constraint(m, x <= 1)
+
+        @test tight_upperbound(x; nta = mip) == 2.0
+    end
+
+    @testset "propagates unexpected errors when reading the MIP objective bound" begin
+        # MockOptimizer throws a KeyError when ObjectiveBound was never set; only the three
+        # whitelisted MOI attribute errors are converted into a fallback to b_0.
+        mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_objective_value = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            mock,
+            optimizer -> MathOptInterface.Utilities.mock_optimize!(
+                optimizer,
+                MathOptInterface.OPTIMAL,
+                [0.999],
+            ),
+        )
+        m = Model(() -> mock)
+        m.ext[:MIPVerify] = MIPVerifyExt(mip)
+        @variable(m, 0 <= x <= 2)
+        @constraint(m, x <= 1)
+
+        @test_throws KeyError tight_upperbound(x; nta = mip)
+    end
+
+    @testset "projected_dual_and_reference ignores unsupported sets" begin
+        @test projected_dual_and_reference(MathOptInterface.ZeroOne(), 1.0) === nothing
+    end
+
+    @testset "constraint_dual_or_nothing classifies retrieval errors" begin
+        unsupported = MathOptInterface.UnsupportedAttribute(MathOptInterface.ConstraintDual())
+        @test constraint_dual_or_nothing(:constraint, _ -> throw(unsupported)) === nothing
+        @test_throws ErrorException constraint_dual_or_nothing(:constraint, _ -> error("boom"))
+    end
+
+    @testset "variable_interval_or_nothing clamps binaries and rejects empty intervals" begin
+        m = Model()
+        b = @variable(m, binary = true)
+        binary_interval = variable_interval_or_nothing(b)
+        @test lower_bound(binary_interval) == 0.0
+        @test upper_bound(binary_interval) == 1.0
+
+        inverted = @variable(m)
+        set_lower_bound(inverted, 1.0)
+        set_upper_bound(inverted, 0.0)
+        @test variable_interval_or_nothing(inverted) === nothing
+    end
+
+    @testset "falls back when a residual variable has an invalid or unbounded interval" begin
+        m_invalid = Model()
+        @variable(m_invalid, 0 <= x <= 1)
+        y = @variable(m_invalid)
+        set_lower_bound(y, 1.0)
+        set_upper_bound(y, 0.0)
+        invalid_result =
+            certified_lp_bound(m_invalid, lower_bound_type, x + y, -2.5; dual_value = _ -> 0.0)
+        @test invalid_result == -2.5
+
+        m_unbounded = Model()
+        @variable(m_unbounded, 0 <= z <= 1)
+        free = @variable(m_unbounded)
+        unbounded_result =
+            certified_lp_bound(m_unbounded, lower_bound_type, z + free, -2.5; dual_value = _ -> 0.0)
+        @test unbounded_result == -2.5
     end
 end

--- a/test/net_components/lp_certification.jl
+++ b/test/net_components/lp_certification.jl
@@ -423,6 +423,45 @@ TestHelpers.@timed_testset "lp_certification.jl" begin
         )
     end
 
+    @testset "errors when a feasible point lies outside the interval-arithmetic bound" begin
+        # A feasible point can never beat a bound that interval arithmetic computed for the
+        # same model; if the solver reports one that does, the solver and our view of the
+        # model disagree and no bound from the run can be trusted.
+        upper_mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_objective_value = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            upper_mock,
+            optimizer -> begin
+                MathOptInterface.Utilities.mock_optimize!(optimizer, MathOptInterface.OPTIMAL, [3.0])
+                MathOptInterface.set(optimizer, MathOptInterface.ObjectiveValue(), 3.0)
+            end,
+        )
+        m_upper = Model(() -> upper_mock)
+        m_upper.ext[:MIPVerify] = MIPVerifyExt(mip)
+        @variable(m_upper, 0 <= x <= 2)
+
+        @test_throws ErrorException tight_upperbound(x; nta = mip)
+
+        lower_mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_objective_value = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            lower_mock,
+            optimizer -> begin
+                MathOptInterface.Utilities.mock_optimize!(optimizer, MathOptInterface.OPTIMAL, [-3.0])
+                MathOptInterface.set(optimizer, MathOptInterface.ObjectiveValue(), -3.0)
+            end,
+        )
+        m_lower = Model(() -> lower_mock)
+        m_lower.ext[:MIPVerify] = MIPVerifyExt(mip)
+        @variable(m_lower, -2 <= y <= 0)
+
+        @test_throws ErrorException tight_lowerbound(y; nta = mip)
+    end
+
     @testset "projected_dual_and_reference ignores unsupported sets" begin
         @test projected_dual_and_reference(MathOptInterface.ZeroOne(), 1.0) === nothing
     end

--- a/test/net_components/lp_certification.jl
+++ b/test/net_components/lp_certification.jl
@@ -1,0 +1,371 @@
+using Test
+
+using HiGHS
+using JuMP
+using MathOptInterface: MathOptInterface
+using MIPVerify:
+    MIPVerifyExt,
+    certified_lp_bound,
+    lower_bound,
+    lower_bound_type,
+    lp,
+    mip,
+    tight_lowerbound,
+    tight_upperbound,
+    upper_bound,
+    upper_bound_type
+
+@isdefined(TestHelpers) || include("../TestHelpers.jl")
+
+TestHelpers.@timed_testset "lp_certification.jl" begin
+    @testset "repairs stationarity residuals over variable bounds" begin
+        m_lower = Model()
+        @variable(m_lower, -2 <= x <= 5)
+        lower_constraint = @constraint(m_lower, x >= 1)
+        lower_dual = Dict(lower_constraint => 1.9)
+        lower = certified_lp_bound(
+            m_lower,
+            lower_bound_type,
+            2x + 3,
+            -1.0;
+            dual_value = constraint -> lower_dual[constraint],
+        )
+        @test lower <= 4.7
+        @test lower ≈ 4.7
+
+        m_upper = Model()
+        @variable(m_upper, -2 <= x <= 5)
+        upper_constraint = @constraint(m_upper, x <= 1)
+        upper_dual = Dict(upper_constraint => -1.9)
+        upper = certified_lp_bound(
+            m_upper,
+            upper_bound_type,
+            2x + 3,
+            13.0;
+            dual_value = constraint -> upper_dual[constraint],
+        )
+        @test upper >= 5.4
+        @test upper ≈ 5.4
+    end
+
+    @testset "uses the correct residual endpoint" begin
+        m_lower = Model()
+        @variable(m_lower, -2 <= x <= 5)
+        lower_constraint = @constraint(m_lower, x >= 1)
+        lower = certified_lp_bound(
+            m_lower,
+            lower_bound_type,
+            2x + 3,
+            -1.0;
+            dual_value = constraint -> constraint == lower_constraint ? 2.1 : 0.0,
+        )
+        @test lower <= 4.6
+        @test lower ≈ 4.6
+
+        m_upper = Model()
+        @variable(m_upper, -2 <= x <= 5)
+        upper_constraint = @constraint(m_upper, x <= 1)
+        upper = certified_lp_bound(
+            m_upper,
+            upper_bound_type,
+            2x + 3,
+            13.0;
+            dual_value = constraint -> constraint == upper_constraint ? -2.1 : 0.0,
+        )
+        @test upper >= 5.3
+        @test upper ≈ 5.3
+    end
+
+    @testset "projects inequality duals onto their cones" begin
+        m = Model()
+        @variable(m, 0 <= x <= 3)
+        useful = @constraint(m, x <= 1)
+        wrong_sign = @constraint(m, -x <= 0)
+        duals = Dict(useful => -1.0, wrong_sign => 0.25)
+
+        bound = certified_lp_bound(
+            m,
+            upper_bound_type,
+            x,
+            3.0;
+            dual_value = constraint -> duals[constraint],
+        )
+
+        @test bound == 1.0
+    end
+
+    @testset "supports equality and interval constraints" begin
+        m_equal = Model()
+        @variable(m_equal, 0 <= x <= 1)
+        equality = @constraint(m_equal, x == 0.5)
+        @test certified_lp_bound(
+            m_equal,
+            lower_bound_type,
+            x,
+            0.0;
+            dual_value = constraint -> constraint == equality ? 1.0 : 0.0,
+        ) == 0.5
+        @test certified_lp_bound(
+            m_equal,
+            upper_bound_type,
+            x,
+            1.0;
+            dual_value = constraint -> constraint == equality ? -1.0 : 0.0,
+        ) == 0.5
+
+        m_interval = Model()
+        @variable(m_interval, 0 <= y <= 1)
+        interval_constraint = @constraint(m_interval, 0.25 <= y <= 0.75)
+        @test certified_lp_bound(
+            m_interval,
+            lower_bound_type,
+            y,
+            0.0;
+            dual_value = constraint -> constraint == interval_constraint ? 1.0 : 0.0,
+        ) == 0.25
+        @test certified_lp_bound(
+            m_interval,
+            upper_bound_type,
+            y,
+            1.0;
+            dual_value = constraint -> constraint == interval_constraint ? -1.0 : 0.0,
+        ) == 0.75
+    end
+
+    @testset "clamps the certificate to the interval bound" begin
+        m_upper = Model()
+        @variable(m_upper, 0 <= x <= 1)
+        upper_constraint = @constraint(m_upper, x <= 100)
+        @test certified_lp_bound(
+            m_upper,
+            upper_bound_type,
+            x,
+            1.0;
+            dual_value = constraint -> constraint == upper_constraint ? -1.0 : 0.0,
+        ) == 1.0
+
+        m_lower = Model()
+        @variable(m_lower, 0 <= x <= 1)
+        lower_constraint = @constraint(m_lower, x >= -100)
+        @test certified_lp_bound(
+            m_lower,
+            lower_bound_type,
+            x,
+            0.0;
+            dual_value = constraint -> constraint == lower_constraint ? 1.0 : 0.0,
+        ) == 0.0
+    end
+
+    @testset "handles fixed and unbounded variables" begin
+        m_fixed = Model()
+        @variable(m_fixed, x)
+        fix(x, 0.5)
+        equality = @constraint(m_fixed, x == 0.5)
+        @test certified_lp_bound(
+            m_fixed,
+            lower_bound_type,
+            x,
+            -1.0;
+            dual_value = constraint -> constraint == equality ? 0.9 : 0.0,
+        ) <= 0.5
+        @test certified_lp_bound(
+            m_fixed,
+            lower_bound_type,
+            x,
+            -1.0;
+            dual_value = constraint -> constraint == equality ? 0.9 : 0.0,
+        ) ≈ 0.5
+
+        m_unbounded = Model()
+        @variable(m_unbounded, x <= 5)
+        upper_constraint = @constraint(m_unbounded, x <= 1)
+        @test certified_lp_bound(
+            m_unbounded,
+            upper_bound_type,
+            x,
+            5.0;
+            dual_value = constraint -> constraint == upper_constraint ? -2.0 : 0.0,
+        ) == 5.0
+        @test certified_lp_bound(
+            m_unbounded,
+            upper_bound_type,
+            x,
+            5.0;
+            dual_value = constraint -> constraint == upper_constraint ? -1.0 : 0.0,
+        ) == 1.0
+
+        m_lower_unbounded = Model()
+        @variable(m_lower_unbounded, x >= -5)
+        lower_constraint = @constraint(m_lower_unbounded, x >= -1)
+        @test certified_lp_bound(
+            m_lower_unbounded,
+            lower_bound_type,
+            x,
+            -5.0;
+            dual_value = constraint -> constraint == lower_constraint ? 2.0 : 0.0,
+        ) == -5.0
+        @test certified_lp_bound(
+            m_lower_unbounded,
+            lower_bound_type,
+            x,
+            -5.0;
+            dual_value = constraint -> constraint == lower_constraint ? 1.0 : 0.0,
+        ) == -1.0
+    end
+
+    @testset "outward-rounds large objective constants" begin
+        m_upper = Model()
+        @variable(m_upper, 0 <= x <= 2)
+        upper_constraint = @constraint(m_upper, x <= 1)
+        upper_objective = x + 1.0e16
+        upper = certified_lp_bound(
+            m_upper,
+            upper_bound_type,
+            upper_objective,
+            upper_bound(upper_objective);
+            dual_value = constraint -> constraint == upper_constraint ? -1.0 : 0.0,
+        )
+        @test BigFloat(upper) >= BigFloat(1.0e16) + 1
+
+        m_lower = Model()
+        @variable(m_lower, -2 <= x <= 0)
+        lower_constraint = @constraint(m_lower, x >= -1)
+        lower_objective = x - 1.0e16
+        lower = certified_lp_bound(
+            m_lower,
+            lower_bound_type,
+            lower_objective,
+            lower_bound(lower_objective);
+            dual_value = constraint -> constraint == lower_constraint ? 1.0 : 0.0,
+        )
+        @test BigFloat(lower) <= BigFloat(-1.0e16) - 1
+    end
+
+    @testset "integrates with HiGHS tightening after presolve" begin
+        m = TestHelpers.get_new_model()
+        m.ext[:MIPVerify] = MIPVerifyExt(lp)
+        @variable(m, 0 <= x <= 1)
+        @constraint(m, x >= 0.3)
+
+        lower = tight_lowerbound(x; nta = lp)
+        upper = tight_upperbound(x; nta = lp)
+
+        # The certified bounds are sound (one-sided) and match the true extrema
+        # only up to solver tolerances and outward rounding.
+        @test lower <= 0.3
+        @test lower ≈ 0.3 atol = 1e-6
+        @test upper >= 1.0
+        @test upper ≈ 1.0 atol = 1e-6
+    end
+
+    @testset "does not use an unsafe primal objective" begin
+        upper_mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_variable_constraint_dual = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            upper_mock,
+            optimizer -> MathOptInterface.Utilities.mock_optimize!(
+                optimizer,
+                MathOptInterface.OPTIMAL,
+                [0.999],
+                (
+                    MathOptInterface.ScalarAffineFunction{Float64},
+                    MathOptInterface.LessThan{Float64},
+                ) => [-1.0],
+            ),
+        )
+        m_upper = Model(() -> upper_mock)
+        m_upper.ext[:MIPVerify] = MIPVerifyExt(lp)
+        @variable(m_upper, 0 <= x <= 2)
+        @constraint(m_upper, x <= 1)
+        @test tight_upperbound(x; nta = lp) == 1.0
+
+        lower_mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_variable_constraint_dual = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            lower_mock,
+            optimizer -> MathOptInterface.Utilities.mock_optimize!(
+                optimizer,
+                MathOptInterface.OPTIMAL,
+                [-0.999],
+                (
+                    MathOptInterface.ScalarAffineFunction{Float64},
+                    MathOptInterface.GreaterThan{Float64},
+                ) => [1.0],
+            ),
+        )
+        m_lower = Model(() -> lower_mock)
+        m_lower.ext[:MIPVerify] = MIPVerifyExt(lp)
+        @variable(m_lower, -2 <= x <= 0)
+        @constraint(m_lower, x >= -1)
+        @test tight_lowerbound(x; nta = lp) == -1.0
+    end
+
+    @testset "falls back when the solver returns no dual solution" begin
+        mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_variable_constraint_dual = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            mock,
+            optimizer -> MathOptInterface.Utilities.mock_optimize!(
+                optimizer,
+                MathOptInterface.OPTIMAL,
+                [0.999],
+            ),
+        )
+        m = Model(() -> mock)
+        m.ext[:MIPVerify] = MIPVerifyExt(lp)
+        @variable(m, 0 <= x <= 2)
+        @constraint(m, x <= 1)
+
+        @test tight_upperbound(x; nta = lp) == 2.0
+    end
+
+    @testset "uses the solver objective bound for MIP tightening" begin
+        upper_mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_objective_value = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            upper_mock,
+            optimizer -> begin
+                MathOptInterface.Utilities.mock_optimize!(optimizer, MathOptInterface.OPTIMAL, [0.999])
+                MathOptInterface.set(optimizer, MathOptInterface.ObjectiveValue(), 0.999)
+                MathOptInterface.set(optimizer, MathOptInterface.ObjectiveBound(), 1.0)
+            end,
+        )
+        m_upper = Model(() -> upper_mock)
+        m_upper.ext[:MIPVerify] = MIPVerifyExt(mip)
+        @variable(m_upper, 0 <= x <= 2)
+        @constraint(m_upper, x <= 1)
+
+        @test tight_upperbound(x; nta = mip) == 1.0
+
+        lower_mock = MathOptInterface.Utilities.MockOptimizer(
+            MathOptInterface.Utilities.Model{Float64}();
+            eval_objective_value = false,
+        )
+        MathOptInterface.Utilities.set_mock_optimize!(
+            lower_mock,
+            optimizer -> begin
+                MathOptInterface.Utilities.mock_optimize!(
+                    optimizer,
+                    MathOptInterface.OPTIMAL,
+                    [-0.999],
+                )
+                MathOptInterface.set(optimizer, MathOptInterface.ObjectiveValue(), -0.999)
+                MathOptInterface.set(optimizer, MathOptInterface.ObjectiveBound(), -1.0)
+            end,
+        )
+        m_lower = Model(() -> lower_mock)
+        m_lower.ext[:MIPVerify] = MIPVerifyExt(mip)
+        @variable(m_lower, -2 <= y <= 0)
+        @constraint(m_lower, y >= -1)
+
+        @test tight_lowerbound(y; nta = mip) == -1.0
+    end
+end

--- a/test/net_components/lp_certification.jl
+++ b/test/net_components/lp_certification.jl
@@ -4,6 +4,7 @@ using HiGHS
 using JuMP
 using MathOptInterface: MathOptInterface
 using MIPVerify:
+    MIPVerify,
     MIPVerifyExt,
     certified_lp_bound,
     constraint_dual_or_nothing,
@@ -393,9 +394,10 @@ TestHelpers.@timed_testset "lp_certification.jl" begin
         @test tight_upperbound(x; nta = mip) == 2.0
     end
 
-    @testset "propagates unexpected errors when reading the MIP objective bound" begin
-        # MockOptimizer throws a KeyError when ObjectiveBound was never set; only the three
-        # whitelisted MOI attribute errors are converted into a fallback to b_0.
+    @testset "falls back when reading the MIP objective bound throws unexpectedly" begin
+        # MockOptimizer throws a KeyError when ObjectiveBound was never set. Unexpected
+        # errors are logged at warn level and treated as an unavailable attribute, so the
+        # bound falls back to b_0 instead of crashing the run.
         mock = MathOptInterface.Utilities.MockOptimizer(
             MathOptInterface.Utilities.Model{Float64}();
             eval_objective_value = false,
@@ -413,7 +415,12 @@ TestHelpers.@timed_testset "lp_certification.jl" begin
         @variable(m, 0 <= x <= 2)
         @constraint(m, x <= 1)
 
-        @test_throws KeyError tight_upperbound(x; nta = mip)
+        MIPVerify.Memento.TestUtils.@test_log(
+            MIPVerify.LOGGER,
+            "warn",
+            "Unexpected error reading the solver objective bound",
+            @test(tight_upperbound(x; nta = mip) == 2.0)
+        )
     end
 
     @testset "projected_dual_and_reference ignores unsupported sets" begin
@@ -421,9 +428,21 @@ TestHelpers.@timed_testset "lp_certification.jl" begin
     end
 
     @testset "constraint_dual_or_nothing classifies retrieval errors" begin
+        # expected MOI attribute-unavailable errors fall back quietly
         unsupported = MathOptInterface.UnsupportedAttribute(MathOptInterface.ConstraintDual())
         @test constraint_dual_or_nothing(:constraint, _ -> throw(unsupported)) === nothing
-        @test_throws ErrorException constraint_dual_or_nothing(:constraint, _ -> error("boom"))
+        # unexpected errors are logged at warn level and treated as unavailable
+        MIPVerify.Memento.TestUtils.@test_log(
+            MIPVerify.LOGGER,
+            "warn",
+            "Unexpected error reading a constraint dual",
+            @test(constraint_dual_or_nothing(:constraint, _ -> error("boom")) === nothing)
+        )
+        # interrupts still propagate
+        @test_throws InterruptException constraint_dual_or_nothing(
+            :constraint,
+            _ -> throw(InterruptException()),
+        )
     end
 
     @testset "variable_interval_or_nothing clamps binaries and rejects empty intervals" begin


### PR DESCRIPTION
## Why this matters

MIPVerify narrows the possible range of each intermediate network value before building the final verification model. Tighter ranges can make the final solve faster, but they also become constraints. An upper bound that is too low or a lower bound that is too high can remove behavior that the original network permits and invalidate the verification result.

Previously, after an optimal LP or MIP solve, tightening used the objective value reported by the numerical solver. Suppose a value has a true maximum of `1.0`, but the solver returns `0.999` within its numerical tolerances. Using `0.999` as the upper bound excludes the real endpoint. The unit tests reproduce this case.

## What changes

| Tightening path | Previous result | New result |
| --- | --- | --- |
| LP | The solver's objective value | A checked bound reconstructed from the LP's dual information |
| MIP | The solver's objective value | The solver's objective bound |

An LP solve can also return row duals, which describe how its constraints combine to bound the objective. MIPVerify now constructs that bound itself. It discards any wrong-sign part of a multiplier. If the multipliers do not cancel the objective exactly, it bounds the leftover terms using each variable's declared range. Interval arithmetic rounds each calculation toward a looser bound, so floating-point rounding cannot accidentally make the result too tight.

The tighter of this checked result and the initial interval-arithmetic bound is returned. If no finite checked result can be produced, MIPVerify keeps the initial bound.

A MIP solver reports both its best solution value and a separate bound on the true optimum. The MIP path now uses the latter, exposed as `objective_bound`. JuMP does not expose enough information to check that bound independently, so this path still relies on the solver's numerical calculation. If `objective_bound` is missing or non-finite, or the solve does not finish with an optimal status, MIPVerify uses the interval-arithmetic result.

## Safeguards

When a finite objective value is available after an optimal solve, MIPVerify checks that it does not cross the corresponding interval-arithmetic bound. If the two differ by more than a small tolerance scaled to the bound's magnitude, the run stops before using questionable bounds.

Unreadable optional solver data are treated as unavailable. Expected missing-attribute errors are quiet, unexpected read errors emit a warning, and tightening continues with the remaining data or the interval-arithmetic result. Debug logs explain certificate-specific fallbacks.

This PR also restores integer constraints even when LP tightening throws, records an inferred lower bound for `maximum_ge` outputs when possible, and adds a helper for comparing paired WK17a benchmark runs. The inferred bound can prevent an avoidable LP-certificate fallback. There is no public API change.

## Validation

- GitHub Actions passes at `f8e02c2`, including the package and benchmark-helper test suites. Tests cover the original `0.999` failure, LP certification, MIP objective-bound handling, fallback behavior, the interval-bound check, and cleanup after errors.
- A paired 500-sample WK17a LP run used matching dependency snapshots for `master` at `1bb2f9d` and this branch. Verification outcomes were unchanged for 499 samples. Sample 246 changed from unresolved at the time limit to certified with no adversarial example.
- Certification increased wall-clock time by 29.8% (3,773.6 s to 4,897.2 s). The added cost was concentrated in model construction and bound tightening. Main-solve time increased by 5.2% in total and had the same median.

The large benchmark covers LP tightening. The MIP path has unit coverage but has not had an equivalent large run. #209 reduces unnecessary certificate work, and #211 tracks batched dual retrieval.
