### PR TITLE
Pin Prettier version in CI and add it to the local format script

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -170,4 +170,8 @@ jobs:
       - name: "Verify that Prettier does not find any code style issues."
         uses: creyD/prettier_action@v4.3
         with:
+          # Keep this version in sync with scripts/format.sh. Without a pin, the action
+          # installs the latest Prettier, and new releases change formatting rules and
+          # break CI on unchanged files.
+          prettier_version: "3.9.5"
           prettier_options: --check **/*.{md,yaml}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -13,3 +13,11 @@ repo_root=$(git rev-parse --show-toplevel)
     format(".", verbose=true)
   '
 )
+
+# Format Markdown and YAML with the same pinned Prettier version that CI uses
+# (see format-check-prettier in .github/workflows/CI.yml).
+if command -v npx > /dev/null; then
+  (cd "${repo_root}" && npx --yes prettier@3.9.5 --write "**/*.{md,yaml}")
+else
+  echo "WARNING: npx not found; skipping Prettier formatting of Markdown and YAML files." >&2
+fi


### PR DESCRIPTION
The Markdown/YAML formatting check installs the latest Prettier on every CI run, so new Prettier releases change formatting rules and fail CI on unchanged files (most recently the 3.9 line, which required reformatting README.md in #210). `scripts/format.sh` also only covered Julia files, so Markdown drift was invisible locally until CI failed.

- Pin the CI check to Prettier 3.9.5.
- Run the same pinned Prettier over `**/*.{md,yaml}` in `scripts/format.sh`, with a warning fallback when `npx` is unavailable.

Master is already clean under 3.9.5, so this changes no existing files.