### PR TITLE
Test bound attribution outside ReLU layers

### DIFF
--- a/test/net_components/core_ops.jl
+++ b/test/net_components/core_ops.jl
@@ -747,6 +747,8 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             m = TestHelpers.get_new_model()
             stats = MIPVerify.VerificationStats()
             m.ext[:MIPVerify] = MIPVerify.MIPVerifyExt(lp, stats)
+            # These bounds straddle zero, so the ReLU exercises both bound paths
+            # instead of fixing the unit active or inactive.
             x = @variable(m, lower_bound = -1, upper_bound = 1)
 
             tight_upperbound(1.0 * x; nta = lp)
@@ -759,7 +761,6 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             @test stats.bound_tightening[(0, "lp", "upper")].solver_call_count == 1
             @test stats.bound_tightening[(0, "lp", "lower")].solver_call_count == 1
             @test haskey(stats.bound_tightening, (1, "interval_arithmetic", "upper"))
-            @test !any(key -> key[1] == 1 && key[2] == "lp", keys(stats.bound_tightening))
         end
 
         @testset "remains disabled by default" begin

--- a/test/net_components/core_ops.jl
+++ b/test/net_components/core_ops.jl
@@ -743,6 +743,25 @@ TestHelpers.@timed_testset "core_ops.jl" begin
             @test count_binary_variables(m) == 0
         end
 
+        @testset "attributes bounds outside ReLU layers to layer index 0" begin
+            m = TestHelpers.get_new_model()
+            stats = MIPVerify.VerificationStats()
+            m.ext[:MIPVerify] = MIPVerify.MIPVerifyExt(lp, stats)
+            x = @variable(m, lower_bound = -1, upper_bound = 1)
+
+            tight_upperbound(1.0 * x; nta = lp)
+            relu([1.0 * x]; nta = interval_arithmetic)
+            tight_lowerbound(1.0 * x; nta = lp)
+
+            # The lower bound solved after the ReLU layer must return to index 0,
+            # proving that finishing a layer resets the attribution index.
+            @test stats.current_relu_layer_index == 0
+            @test stats.bound_tightening[(0, "lp", "upper")].solver_call_count == 1
+            @test stats.bound_tightening[(0, "lp", "lower")].solver_call_count == 1
+            @test haskey(stats.bound_tightening, (1, "interval_arithmetic", "upper"))
+            @test !any(key -> key[1] == 1 && key[2] == "lp", keys(stats.bound_tightening))
+        end
+
         @testset "remains disabled by default" begin
             m = TestHelpers.get_new_model()
             m.ext[:MIPVerify] = MIPVerify.MIPVerifyExt(interval_arithmetic)


### PR DESCRIPTION
## Why this matters

The WK17a benchmark computes per-sample bound-tightening time by adding each rectified linear unit (ReLU) layer's bounds-phase time to solver time recorded outside a layer. `VerificationStats` uses layer index `0` for that outside-layer bucket. If a completed layer remained current, a later bound solve would be grouped with the old layer and omitted from this total.

## What changes

This PR adds direct regression coverage for the attribution behavior introduced in #214. The test uses a variable bounded from `-1` to `1`, so its ReLU can be active or inactive and both bound paths run. It performs a linear programming (LP) upper-bound solve before the ReLU layer, runs layer `1` using interval arithmetic, and performs an LP lower-bound solve afterward.

The assertions verify that the current index returns to `0` when the layer completes, both surrounding solver calls are recorded under index `0`, and the ReLU has an interval-arithmetic upper-bound record under layer `1`.

This is a test-only change; production instrumentation and benchmark behavior are unchanged.

## Validation

- `julia --project=test test/net_components/core_ops.jl`: 184/184 tests pass
- GitHub Actions: all 14 checks pass for `f7d30ea` against `ed9194c`
