### PR TITLE
Document test project setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,13 @@ MIPVerify     |  518       1    519  3m18.6s
 
 ### Running a subset of tests locally
 
-For faster iteration, run a test file directly from the test project. For example:
+After cloning the repository or changing test dependencies, instantiate the test project:
+
+```sh
+julia --project=test -e 'using Pkg; Pkg.instantiate()'
+```
+
+Then run a test file directly for faster iteration. For example:
 
 ```sh
 julia --project=test test/models.jl


### PR DESCRIPTION
## Why

The subset-test command in `CONTRIBUTING.md` assumes the test project has already been instantiated. On a fresh checkout, Julia reports missing test dependencies.

## What changed

Document the one-time `Pkg.instantiate()` step before running individual test files through `--project=test`.

## Validation

- `julia --project=test -e 'using Pkg; Pkg.instantiate()'`
- `julia --project=test test/models.jl` (3/3 passed)
- `./scripts/format.sh`
