### PR TITLE
Add Ruff formatting check to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,6 +118,21 @@ jobs:
               exit(1)
           end'
 
+  format-check-python:
+    name: "Check Formatting and Linting (.py)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Verify that Ruff does not find any code style issues."
+        uses: astral-sh/ruff-action@v4.1.0
+        with:
+          # Keep this version in sync with scripts/format.sh.
+          version: "0.15.21"
+          args: "format --check --diff"
+          src: "benchmarks/analysis/"
+      - name: "Verify that Ruff does not find any lint issues."
+        run: ruff check benchmarks/analysis/
+
   benchmark-tests:
     name: Benchmark Helper Tests
     runs-on: ubuntu-latest

--- a/benchmarks/analysis/analyze_pair.py
+++ b/benchmarks/analysis/analyze_pair.py
@@ -152,7 +152,10 @@ def series_stats(series: Series, frame: pd.DataFrame) -> dict:
     top10_share = float(cum[min(10, n) - 1] / total_abs) if total_abs > 0 else float("nan")
     k5 = max(1, math.ceil(0.05 * n))
     top5pct_share = float(cum[k5 - 1] / total_abs) if total_abs > 0 else float("nan")
-    q = lambda x: float(np.quantile(ratios, x))
+
+    def q(x):
+        return float(np.quantile(ratios, x))
+
     return {
         "series": series.key,
         "label": series.label,

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -14,6 +14,14 @@ repo_root=$(git rev-parse --show-toplevel)
   '
 )
 
+# Format benchmark analysis Python with the same pinned Ruff version that CI uses
+# (see format-check-python in .github/workflows/CI.yml).
+if command -v uvx > /dev/null; then
+  (cd "${repo_root}" && uvx ruff@0.15.21 format benchmarks/analysis/)
+else
+  echo "WARNING: uvx not found; skipping Ruff formatting of Python files." >&2
+fi
+
 # Format Markdown and YAML with the same pinned Prettier version that CI uses
 # (see format-check-prettier in .github/workflows/CI.yml).
 if command -v npx > /dev/null; then


### PR DESCRIPTION
`benchmarks/analysis/` already defines Ruff rules, but CI did not enforce formatting or linting. Python changes could therefore drift from the configured style or introduce default Ruff violations without a CI failure.

## What changes

- Add a `Check Formatting and Linting (.py)` job that runs Ruff 0.15.21's `format --check --diff` and `ruff check` against `benchmarks/analysis/`.
- Run the same pinned formatter from `scripts/format.sh` so contributors can apply the CI formatting locally.
- Replace the analysis script's lone E731 lambda assignment with an equivalent nested function so the existing code passes the lint gate.
- Warn and skip the local Python formatter when `uvx` is unavailable; the dedicated CI job uses `ruff-action` independently.

## Validation

- The new `Check Formatting and Linting (.py)` GitHub Actions job passed for head `0bb136d`.
- `ruff format --check --diff benchmarks/analysis/` reports that the analysis file is already formatted.
- `ruff check benchmarks/analysis/` passes.
- Bash syntax validation for `scripts/format.sh` and YAML parsing for `.github/workflows/CI.yml` passed.

Closes #224.
