### PR TITLE
Cache Julia package state for docs and benchmark CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,10 +113,12 @@ jobs:
         run: |
           version_prefix="${RUNNER_OS}-${RUNNER_ARCH}-docs-julia-${JULIA_VERSION}-"
           project_prefix="${version_prefix}projects-${PROJECT_HASH}-manifest-"
-          echo "unresolved=${project_prefix}unresolved" >> "$GITHUB_OUTPUT"
-          echo "project_prefix=${project_prefix}" >> "$GITHUB_OUTPUT"
-          echo "version_prefix=${version_prefix}" >> "$GITHUB_OUTPUT"
-          echo "legacy_version_prefix=${RUNNER_OS}-docs-julia-${JULIA_VERSION}-" >> "$GITHUB_OUTPUT"
+          {
+            echo "unresolved=${project_prefix}unresolved"
+            echo "project_prefix=${project_prefix}"
+            echo "version_prefix=${version_prefix}"
+            echo "legacy_version_prefix=${RUNNER_OS}-docs-julia-${JULIA_VERSION}-"
+          } >> "$GITHUB_OUTPUT"
       - name: Restore documentation Julia package state
         id: docs-restore
         uses: actions/cache/restore@v6
@@ -226,10 +228,12 @@ jobs:
         run: |
           version_prefix="${RUNNER_OS}-${RUNNER_ARCH}-benchmarks-julia-${JULIA_VERSION}-"
           project_prefix="${version_prefix}projects-${PROJECT_HASH}-manifest-"
-          echo "unresolved=${project_prefix}unresolved" >> "$GITHUB_OUTPUT"
-          echo "project_prefix=${project_prefix}" >> "$GITHUB_OUTPUT"
-          echo "version_prefix=${version_prefix}" >> "$GITHUB_OUTPUT"
-          echo "legacy_version_prefix=${RUNNER_OS}-benchmarks-julia-${JULIA_VERSION}-" >> "$GITHUB_OUTPUT"
+          {
+            echo "unresolved=${project_prefix}unresolved"
+            echo "project_prefix=${project_prefix}"
+            echo "version_prefix=${version_prefix}"
+            echo "legacy_version_prefix=${RUNNER_OS}-benchmarks-julia-${JULIA_VERSION}-"
+          } >> "$GITHUB_OUTPUT"
       - name: Restore benchmark Julia package state
         id: benchmark-restore
         uses: actions/cache/restore@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,8 +73,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
+        id: setup-julia
         with:
           version: "1"
+      - name: Set weekly cache epoch
+        id: cache-epoch
+        run: echo "value=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+      - name: Cache documentation Julia depot
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/compiled
+            ~/.julia/packages
+            ~/.julia/registries
+          key: ${{ runner.os }}-docs-julia-${{ steps.setup-julia.outputs.julia-version }}-${{ steps.cache-epoch.outputs.value }}-${{ hashFiles('Project.toml', 'docs/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-julia-${{ steps.setup-julia.outputs.julia-version }}-
       - run: |
           julia --project=docs -e '
             using Pkg
@@ -139,8 +154,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
+        id: setup-julia
         with:
           version: "1"
+      - name: Set weekly cache epoch
+        id: cache-epoch
+        run: echo "value=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+      - name: Cache benchmark Julia depot
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/compiled
+            ~/.julia/packages
+            ~/.julia/registries
+          key: ${{ runner.os }}-benchmarks-julia-${{ steps.setup-julia.outputs.julia-version }}-${{ steps.cache-epoch.outputs.value }}-${{ hashFiles('Project.toml', 'benchmarks/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-benchmarks-julia-${{ steps.setup-julia.outputs.julia-version }}-
       - name: Instantiate benchmarks environment
         run: julia --project=benchmarks -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
       - name: Run benchmark helper tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,25 +76,47 @@ jobs:
         id: setup-julia
         with:
           version: "1"
-      - name: Set weekly cache epoch
-        id: cache-epoch
-        run: echo "value=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-      - name: Cache documentation Julia depot
-        uses: actions/cache@v4
+      - name: Compute documentation Julia package state restore keys
+        id: docs-restore-keys
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_ARCH: ${{ runner.arch }}
+          JULIA_VERSION: ${{ steps.setup-julia.outputs.julia-version }}
+          PROJECT_HASH: ${{ hashFiles('Project.toml', 'docs/Project.toml') }}
+        run: |
+          version_prefix="${RUNNER_OS}-${RUNNER_ARCH}-docs-julia-${JULIA_VERSION}-"
+          project_prefix="${version_prefix}projects-${PROJECT_HASH}-manifest-"
+          echo "unresolved=${project_prefix}unresolved" >> "$GITHUB_OUTPUT"
+          echo "project_prefix=${project_prefix}" >> "$GITHUB_OUTPUT"
+          echo "version_prefix=${version_prefix}" >> "$GITHUB_OUTPUT"
+          echo "legacy_version_prefix=${RUNNER_OS}-docs-julia-${JULIA_VERSION}-" >> "$GITHUB_OUTPUT"
+      - name: Restore documentation Julia package state
+        id: docs-restore
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.julia/artifacts
             ~/.julia/compiled
             ~/.julia/packages
             ~/.julia/registries
-          key: ${{ runner.os }}-docs-julia-${{ steps.setup-julia.outputs.julia-version }}-${{ steps.cache-epoch.outputs.value }}-${{ hashFiles('Project.toml', 'docs/Project.toml') }}
+          # The manifest is generated during instantiation. Use a sentinel lookup,
+          # then seed from the newest cache for this project or Julia version.
+          key: ${{ steps.docs-restore-keys.outputs.unresolved }}
           restore-keys: |
-            ${{ runner.os }}-docs-julia-${{ steps.setup-julia.outputs.julia-version }}-
+            ${{ steps.docs-restore-keys.outputs.project_prefix }}
+            ${{ steps.docs-restore-keys.outputs.version_prefix }}
+            ${{ steps.docs-restore-keys.outputs.legacy_version_prefix }}
       - run: |
           julia --project=docs -e '
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
+      - name: Compute final documentation Julia package state key
+        id: docs-final-key
+        env:
+          PROJECT_PREFIX: ${{ steps.docs-restore-keys.outputs.project_prefix }}
+          MANIFEST_HASH: ${{ hashFiles('docs/Manifest.toml') }}
+        run: echo "key=${PROJECT_PREFIX}${MANIFEST_HASH}" >> "$GITHUB_OUTPUT"
       - run: |
           julia --project=docs -e '
             using Documenter: doctest
@@ -106,6 +128,16 @@ jobs:
           # I created a `DOCUMENTER_KEY` secret, via
           # https://discourse.julialang.org/t/easy-workflow-file-for-setting-up-github-actions-ci-for-your-julia-package/49765/46
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - name: Save documentation Julia package state
+        if: ${{ success() && steps.docs-final-key.outputs.key != steps.docs-restore.outputs.cache-matched-key }}
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/compiled
+            ~/.julia/packages
+            ~/.julia/registries
+          key: ${{ steps.docs-final-key.outputs.key }}
 
   # JuliaFormatter check, based off of
   # https://github.com/julia-actions/julia-format/blob/096371fb8d24867760569a7a89359a677595503b/workflows/format_check.yml
@@ -157,24 +189,56 @@ jobs:
         id: setup-julia
         with:
           version: "1"
-      - name: Set weekly cache epoch
-        id: cache-epoch
-        run: echo "value=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-      - name: Cache benchmark Julia depot
-        uses: actions/cache@v4
+      - name: Compute benchmark Julia package state restore keys
+        id: benchmark-restore-keys
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_ARCH: ${{ runner.arch }}
+          JULIA_VERSION: ${{ steps.setup-julia.outputs.julia-version }}
+          PROJECT_HASH: ${{ hashFiles('Project.toml', 'benchmarks/Project.toml', 'examples/Project.toml', 'test/Project.toml') }}
+        run: |
+          version_prefix="${RUNNER_OS}-${RUNNER_ARCH}-benchmarks-julia-${JULIA_VERSION}-"
+          project_prefix="${version_prefix}projects-${PROJECT_HASH}-manifest-"
+          echo "unresolved=${project_prefix}unresolved" >> "$GITHUB_OUTPUT"
+          echo "project_prefix=${project_prefix}" >> "$GITHUB_OUTPUT"
+          echo "version_prefix=${version_prefix}" >> "$GITHUB_OUTPUT"
+          echo "legacy_version_prefix=${RUNNER_OS}-benchmarks-julia-${JULIA_VERSION}-" >> "$GITHUB_OUTPUT"
+      - name: Restore benchmark Julia package state
+        id: benchmark-restore
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.julia/artifacts
             ~/.julia/compiled
             ~/.julia/packages
             ~/.julia/registries
-          key: ${{ runner.os }}-benchmarks-julia-${{ steps.setup-julia.outputs.julia-version }}-${{ steps.cache-epoch.outputs.value }}-${{ hashFiles('Project.toml', 'benchmarks/Project.toml') }}
+          # The workspace manifest is generated during instantiation. Use a sentinel lookup,
+          # then seed from the newest cache for this project or Julia version.
+          key: ${{ steps.benchmark-restore-keys.outputs.unresolved }}
           restore-keys: |
-            ${{ runner.os }}-benchmarks-julia-${{ steps.setup-julia.outputs.julia-version }}-
+            ${{ steps.benchmark-restore-keys.outputs.project_prefix }}
+            ${{ steps.benchmark-restore-keys.outputs.version_prefix }}
+            ${{ steps.benchmark-restore-keys.outputs.legacy_version_prefix }}
       - name: Instantiate benchmarks environment
         run: julia --project=benchmarks -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
+      - name: Compute final benchmark Julia package state key
+        id: benchmark-final-key
+        env:
+          PROJECT_PREFIX: ${{ steps.benchmark-restore-keys.outputs.project_prefix }}
+          MANIFEST_HASH: ${{ hashFiles('Manifest.toml') }}
+        run: echo "key=${PROJECT_PREFIX}${MANIFEST_HASH}" >> "$GITHUB_OUTPUT"
       - name: Run benchmark helper tests
         run: julia --project=benchmarks benchmarks/test/runtests.jl
+      - name: Save benchmark Julia package state
+        if: ${{ success() && steps.benchmark-final-key.outputs.key != steps.benchmark-restore.outputs.cache-matched-key }}
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/compiled
+            ~/.julia/packages
+            ~/.julia/registries
+          key: ${{ steps.benchmark-final-key.outputs.key }}
 
   notebook-tests:
     name: "Notebook: ${{ matrix.notebook }}"


### PR DESCRIPTION
## Why

Dependency setup dominates two small CI jobs. In the audited [PR #221 run](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29480247853), documentation spent 179 seconds instantiating dependencies before 43 seconds of checks; benchmark helpers spent 186 seconds instantiating dependencies before 22 seconds of tests.

The repository is close to its 10 GB Actions cache limit, so this change targets these two non-matrix jobs instead of adding package-state caches across the full CI matrix.

## What changed

- Restore package sources, artifacts, registries, and compiled package caches before the documentation and benchmark helper environments are instantiated.
- Restrict restore candidates to the same operating system, architecture, job, and exact Julia version, preferring entries with the same project-file hashes.
- After Julia resolves the environment, combine the project-file hashes with the generated `Manifest.toml` hash to form the final cache key.
- Save after successful checks only when the job did not restore that exact final key.
- Use `actions/cache/restore@v6` and `actions/cache/save@v6`.

## Why the key is dependency-based

GitHub cache entries are immutable, while this repository intentionally does not commit manifests. The project files identify the declared environments, and the generated manifest identifies the resolved dependency graph. Combining both in the final key refreshes the cache when either changes. A new week, or a registry update that leaves the resolution unchanged, does not rotate the key.

Before the manifest exists, the job seeds the depot from the newest compatible cache. After resolution, the final key determines whether a new entry is needed.

## Scope

- The documentation and benchmark helper jobs now restore and save Julia package state.
- The Julia package-test matrix, notebook jobs, and formatting jobs have no workflow changes.

## Validation

- The [manifest-keyed CI run](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29523498105/attempts/1) restored the two earlier cache entries, generated `docs/Manifest.toml` and the workspace-root `Manifest.toml`, and saved final manifest-derived entries.
- Job-only reruns restored those exact final keys, recomputed the same manifest hashes, and skipped both save steps.
- Documentation completed its doctest and build; benchmark helper tests passed 83/83.
- All 15 CI checks pass for the current PR head and base.
- `actionlint` reports only the workflow's pre-existing stale-action-version warnings, and `git diff --check` passes.

## Timing

Only the two changed jobs are timed here. The unchanged job groups above are not expected to move.

| Job | [No package-state cache](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29487748117) | [First manifest-keyed run](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29523498105/attempts/1) | Exact-key rerun |
| --- | ---: | ---: | ---: |
| Documentation | 205s | 77s | [55s](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29523498105/attempts/2) |
| Benchmark Helper Tests | 210s | 58s | [51s](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29523498105/attempts/3) |

The migration run restored the earlier entries and saved the final keys. The exact-key reruns restored those keys and skipped saving. The two final entries total 391.3 MiB.
