### PR TITLE
Remove duplicate doctest and formatting work from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -161,11 +161,6 @@ jobs:
           PROJECT_PREFIX: ${{ steps.docs-restore-keys.outputs.project_prefix }}
           MANIFEST_HASH: ${{ hashFiles('docs/Manifest.toml') }}
         run: echo "key=${PROJECT_PREFIX}${MANIFEST_HASH}" >> "$GITHUB_OUTPUT"
-      - run: |
-          julia --project=docs -e '
-            using Documenter: doctest
-            using MIPVerify
-            doctest(MIPVerify)'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -194,7 +189,7 @@ jobs:
         with:
           version: "1"
       - name: "Run `format.sh` script (runs `JuliaFormatter.format` on all files)"
-        run: ./scripts/format.sh
+        run: ./scripts/format.sh --julia-only
       - name: "Verify that running `JuliaFormatter.format` is a no-op."
         run: |
           # The backticks below are Julia Cmd-literal syntax, not shell substitution

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,6 +3,16 @@
 # Determining root directory of the repo: https://stackoverflow.com/a/957978
 repo_root=$(git rev-parse --show-toplevel)
 
+julia_only=false
+if [[ $# -gt 0 ]]; then
+  if [[ $# -eq 1 && $1 == "--julia-only" ]]; then
+    julia_only=true
+  else
+    echo "Usage: $0 [--julia-only]" >&2
+    exit 2
+  fi
+fi
+
 (
   cd "${repo_root}" &&
   julia -e '
@@ -13,6 +23,11 @@ repo_root=$(git rev-parse --show-toplevel)
     format(".", verbose=true)
   '
 )
+
+julia_formatter_status=$?
+if [[ "${julia_only}" == true ]]; then
+  exit "${julia_formatter_status}"
+fi
 
 # Format benchmark analysis Python with the same pinned Ruff version that CI uses
 # (see format-check-python in .github/workflows/CI.yml).


### PR DESCRIPTION
## Why

The documentation job runs the same doctests twice: once through an explicit `Documenter.doctest` command and again inside `makedocs`. The Julia-format job also invokes the repository-wide formatter, repeating Prettier work already covered by a separate job and, when `uvx` is available, Ruff work covered by the Python-format job.

## What changed

- Remove the standalone doctest step and keep `docs/make.jl` as the documentation check.
- Add `./scripts/format.sh --julia-only` and use it in the Julia-format job.
- Keep the no-argument `./scripts/format.sh` behavior unchanged for local use: it still runs JuliaFormatter plus the pinned Ruff and Prettier versions.
- Keep existing job and check names.

## Impact

CI performs each check once while retaining the same doctest and formatting failure coverage.

## No-op validation

- `docs/make.jl` completed and logged `Doctest: running doctests`.
- A temporary incorrect doctest made that command fail with a Documenter doctest error.
- `--julia-only` reformatted a Julia probe while leaving Python and Markdown probes byte-identical.
- The no-argument script then formatted the Python probe with Ruff and the Markdown probe with Prettier.
- The pinned Prettier check, shell syntax check, and `git diff --check` pass. Actionlint reports only the workflow's pre-existing stale-action-version warnings.
- An invalid formatter option exits 2, and a missing Julia executable propagates exit 127 from `--julia-only`.

All temporary probes were removed.

## Paired timing

The [master run](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29487748117) and [candidate run](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29488928669) show only the commands changed by this PR. Setup and dependency-instantiation steps are unchanged controls and are omitted because their times varied between runners.

| Command changed by this PR | Master | Candidate | Saved |
| --- | ---: | ---: | ---: |
| Documentation checks after dependency setup | 40s | 28s | 12s |
| Julia formatter command | 47s | 40s | 7s |
