### PR TITLE
Update stale GitHub Actions to current majors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,14 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+          # Upload exactly the file julia-processcoverage produced instead of also
+          # searching the workspace for anything coverage-shaped.
+          disable_search: true
           use_oidc: true
+          # Fail the job when the upload breaks: the action's lenient default let
+          # rate-limited uploads drop silently and would equally hide a broken OIDC
+          # setup. Fork PRs cannot obtain an OIDC token, so stay lenient there.
+          fail_ci_if_error: ${{ !github.event.pull_request.head.repo.fork }}
 
   docs:
     name: Documentation

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,14 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      # Lets the Codecov upload authenticate via GitHub OIDC. The repository has no
+      # CODECOV_TOKEN secret, and codecov-action v4+ rejects unauthenticated uploads
+      # from this repository's own branches ("Token required because branch is
+      # protected"). Fork PRs are not granted this permission; their uploads fail
+      # without failing CI, matching previous behavior.
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +74,7 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+          use_oidc: true
 
   docs:
     name: Documentation

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,13 +39,13 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
           show-versioninfo: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@v6
         env:
           cache-name: cache-artifacts
         with:
@@ -63,15 +63,15 @@ jobs:
           # Julia version cannot silently disable this check.
           MIPVERIFY_RUN_LARGE_DATASET_TESTS: ${{ matrix.os == 'ubuntu-latest' && matrix.version == '1' && 'true' || 'false' }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v7
         with:
-          file: lcov.info
+          files: lcov.info
 
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v1
         with:
           version: "1"
@@ -98,7 +98,7 @@ jobs:
     name: "Check Formatting (.jl)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@latest
         with:
           version: "1"
@@ -122,7 +122,7 @@ jobs:
     name: "Check Formatting and Linting (.py)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: "Verify that Ruff does not find any code style issues."
         uses: astral-sh/ruff-action@v4.1.0
         with:
@@ -137,7 +137,7 @@ jobs:
     name: Benchmark Helper Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v1
         with:
           version: "1"
@@ -160,11 +160,11 @@ jobs:
           - "03_interpreting_the_output_of_find_adversarial_example.ipynb"
           - "04_managing_log_output.ipynb"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v1
         with:
           version: "1"
-      - uses: actions/cache@v3
+      - uses: actions/cache@v6
         env:
           cache-name: cache-artifacts
         with:
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: "Verify that Prettier does not find any code style issues."
         uses: creyD/prettier_action@v4.3
         with:

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     name: WK17a Benchmark (500 samples)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: master
 
@@ -22,7 +22,7 @@ jobs:
           version: "1"
           show-versioninfo: true
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v6
         env:
           cache-name: cache-artifacts-benchmark
         with:


### PR DESCRIPTION
## Why

`actionlint` flags 12 warnings across `CI.yml` and `nightly-benchmark.yml`: `actions/checkout@v3`, `actions/cache@v3`, and `codecov/codecov-action@v3` run on a Node runtime that GitHub has deprecated. These are the pre-existing warnings that PR #227 excluded from its lint check.

## What changed

- `actions/checkout@v3` → `@v7` (9 uses across both workflows)
- `actions/cache@v3` → `@v6` (3 uses)
- `codecov/codecov-action@v3` → `@v7`, with the upload input renamed from `file` to `files` (the singular form was removed in v5)
- Codecov uploads now authenticate via GitHub OIDC (`use_oidc: true` plus `id-token: write` on the test job). The v3 uploader's legacy endpoint accepted anonymous uploads from this repository's own branches (rate-limited, hence the HTTP 429s in #227); the v4+ CLI rejects them outright ("Token required because branch is protected"), so without authentication this bump would have silently stopped all coverage uploads, including master's. The repository has no `CODECOV_TOKEN` secret; OIDC needs no secret.
- The upload step also sets `disable_search: true` (upload exactly the `lcov.info` that julia-processcoverage produced, instead of also scanning the workspace for coverage-shaped files) and `fail_ci_if_error` (a failed upload now fails the leg instead of dropping silently — except on fork PRs, which cannot obtain an OIDC token and stay lenient).

The intermediate majors are Node-runtime upgrades (v2.327.1+ runners, satisfied by GitHub-hosted runners) with no interface changes affecting these workflows: neither workflow relies on persisted checkout credentials (changed in checkout v6) or `pull_request_target`/`workflow_run` fork checkout (restricted in checkout v7).

## Validation

- `actionlint` now passes with no warnings and no exclusions.
- `git diff --check` passes.
- PR CI exercises the bumped checkout, cache, and codecov steps directly. With `fail_ci_if_error` set, a green test leg now proves the Codecov upload itself succeeded. `nightly-benchmark.yml` only runs on schedule/manual dispatch, but uses the same checkout and cache bumps validated here.

## Notes

- The `actions/cache` major bump changes the internal cache version, so the first run repopulates artifact caches; later runs hit as before.
- Touches lines adjacent to #227's changes in `CI.yml`; whichever merges second needs a trivial rebase.
