### PR TITLE
Ignore Claude Code worktrees and local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ TODO.md
 # omit Manifest.toml from packages, per
 # https://discourse.julialang.org/t/does-manifest-toml-belong-in-the-repository/12029/13
 Manifest.toml
+
+# Claude Code: agent worktrees are throwaway full working copies, and the "local"
+# settings variant is per-user by design. Shared agent config (.claude/settings.json,
+# .claude/skills/, .claude/agents/) stays trackable.
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
## Why

`.claude/worktrees/` holds full throwaway working copies created by agent worktree isolation; a duplicate checkout inside the repo confuses tools that scan the tree (and shows as untracked noise in `git status`). `.claude/settings.local.json` is the per-user settings variant, intended to stay out of version control.

## What changed

Ignore `.claude/worktrees/` and `.claude/settings.local.json` only. Shared agent config (`.claude/settings.json`, `.claude/skills/`, `.claude/agents/`) stays trackable, so a blanket `.claude/` ignore is deliberately avoided.

Nothing under `.claude/` is currently tracked, so this changes no repository contents — `git check-ignore` confirms both paths match and `git status` is clean.