### PR TITLE
Bump setup-julia to v3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,10 +58,15 @@ jobs:
             primary: true
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+          # macos-latest runners are Apple Silicon; requesting x64 there runs Julia
+          # under Rosetta 2, which setup-julia v3 rejects unless forced. Forcing
+          # preserves the long-standing tested binaries and check names; moving the
+          # macOS legs to native aarch64 would be a separate, deliberate change.
+          force-arch: ${{ matrix.os == 'macos-latest' }}
           show-versioninfo: true
       - uses: actions/cache@v6
         env:
@@ -99,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - run: |
@@ -126,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - name: "Run `format.sh` script (runs `JuliaFormatter.format` on all files)"
@@ -165,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - name: Instantiate benchmarks environment
@@ -188,7 +193,7 @@ jobs:
           - "04_managing_log_output.ipynb"
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - uses: actions/cache@v6

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: master
 
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
           show-versioninfo: true


### PR DESCRIPTION
## Why

`julia-actions/setup-julia@v1` targets Node 20, which GitHub has deprecated — every job currently carries a "forced to run on Node.js 24" warning annotation. The `format-check-julia` job also floats on `@latest`, unpinned.

## What changed

- `setup-julia@v1` → `@v3` (5 uses in `CI.yml`, 1 in `nightly-benchmark.yml`)
- `setup-julia@latest` → `@v3` in `format-check-julia`
- The test matrix's macOS legs set `force-arch: true`: `macos-latest` runners are Apple Silicon, and the matrix requests `x64`, which runs Julia under Rosetta 2. v3 rejects that cross-arch request unless forced (v2 warned; v1 was silent). Forcing preserves the long-standing tested binaries and the required-check names (`Julia * - macos-latest - x64`).

## Breaking changes reviewed

- v2: Node 20 runtime only.
- v3: Node 24 (fine on GitHub-hosted runners); `version: min` resolution changed (unused here); the Apple Silicon cross-arch error handled above. The `julia-version` output used by in-flight PR #230 exists in v3.

## Validation

- `actionlint` + shellcheck pass locally.
- This PR's own CI exercises all bumped call sites, including both Rosetta macOS legs.

## Note

Moving the macOS legs to native aarch64 Julia would likely speed them up (they are the slowest legs at 11–14 min) and test what Apple-Silicon users actually run, but it changes required-check names, so it is left as a separate decision.

Held out of auto-merge until #228 and #230 land to respect their merge order.