### PR TITLE
Run macOS CI legs on native aarch64 Julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,9 +44,16 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - x64
         include:
+          # Per-OS architecture: macos-latest runners are Apple Silicon, so those
+          # legs run native aarch64 Julia (previously x64 under Rosetta 2); Linux
+          # and Windows runners are x64.
+          - os: ubuntu-latest
+            arch: x64
+          - os: windows-latest
+            arch: x64
+          - os: macos-latest
+            arch: aarch64
           # Designate one leg to carry once-per-run work: validating the large
           # CIFAR10 asset, and collecting and uploading coverage. Doing both on the
           # same leg keeps the coverage report inclusive of the CIFAR10 code path.
@@ -62,22 +69,20 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-          # macos-latest runners are Apple Silicon; requesting x64 there runs Julia
-          # under Rosetta 2, which setup-julia v3 rejects unless forced. Forcing
-          # preserves the long-standing tested binaries and check names; moving the
-          # macOS legs to native aarch64 would be a separate, deliberate change.
-          force-arch: ${{ matrix.os == 'macos-latest' }}
           show-versioninfo: true
       - uses: actions/cache@v6
         env:
           cache-name: cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          # runner.arch is part of the key because artifacts are arch-specific and
+          # macOS runs a different architecture from the other legs. Without it,
+          # the aarch64 legs would exact-hit the x64 key and never save their own.
+          key: ${{ runner.os }}-${{ runner.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+            ${{ runner.os }}-${{ runner.arch }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ runner.arch }}-test-
+            ${{ runner.os }}-${{ runner.arch }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,10 +58,15 @@ jobs:
             primary: true
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+          # macos-latest runners are Apple Silicon; requesting x64 there runs Julia
+          # under Rosetta 2, which setup-julia v3 rejects unless forced. Forcing
+          # preserves the long-standing tested binaries and check names; moving the
+          # macOS legs to native aarch64 would be a separate, deliberate change.
+          force-arch: ${{ matrix.os == 'macos-latest' }}
           show-versioninfo: true
       - uses: actions/cache@v6
         env:
@@ -99,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - run: |
@@ -126,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - name: "Run `format.sh` script (runs `JuliaFormatter.format` on all files)"
@@ -165,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - name: Instantiate benchmarks environment
@@ -188,7 +193,7 @@ jobs:
           - "04_managing_log_output.ipynb"
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - uses: actions/cache@v6

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: master
 
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
           show-versioninfo: true


### PR DESCRIPTION
## Why

Stacked on #236. The `x64` macOS legs date from Intel runners; `macos-latest` is Apple Silicon, so they run Julia under Rosetta 2 — the slowest legs in the matrix (11–14 min), testing binaries Apple Silicon users don't run.

## What changed

- `arch` moves from a single-value matrix axis to per-OS `include` entries: Linux/Windows stay `x64`, macOS becomes `aarch64`. Still six legs; the `primary` designation is unchanged.
- The `force-arch` opt-in from #236 is dropped — every leg now requests its runner's native architecture.
- `runner.arch` joins the artifact cache key: artifacts are arch-specific, and without it the aarch64 legs would exact-hit the existing x64 key and never save a native copy. (One-time cache repopulation for all test legs.)

## Check-name change

`Julia 1 - macos-latest - x64` and `Julia 1.12 - macos-latest - x64` become `... - aarch64`. Landing order: once this PR's checks demonstrate the aarch64 legs pass, the two old macOS names come out of the branch-protection required list and the two new names go in — the old names must be removed **before** merging, since this PR's runs never report them.

## Validation

- `actionlint` + shellcheck pass locally.
- A matrix-expansion simulation confirms six legs (macOS pair aarch64, others x64) and exactly one `primary` leg.
- This PR's CI runs both aarch64 macOS legs.