### PR TITLE
Add agent instructions for flaky CI failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ For failures unrelated to the PR's changes:
 2. If an issue matches, append a row to its "Occurrences" table (date, branch or PR with short SHA,
    linked job name) and add a comment with the specifics: job link, observed vs expected values or
    crash site, dependency versions from the log. Update the issue title if the new occurrence
-   invalidates a qualifier in it (for example, a Julia version or OS that no longer holds).
+   invalidates a qualifier in it (for example, a Julia version or OS that no longer holds). Read the
+   resolved versions from the job log rather than from the check name — the "1" and "1.12" matrix
+   selectors can resolve to the same Julia version.
 3. If nothing matches, open a new issue titled "Flaky CI: <signature>" with the failure details,
    versions, a job link, and an "Occurrences" table ending with "Append new occurrences to this
    table."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md
+
+## Flaky CI failures
+
+When a CI job fails on a PR, read the failure log and classify it before rerunning. A failure in
+code or config the PR touches is not flake — debug it instead.
+
+For failures unrelated to the PR's changes:
+
+1. Search open issues titled "Flaky CI" for a matching signature (failing test case, error type,
+   crash stack site). Known trackers: #218 (intermittent HiGHS segfault during the test suite), #219
+   (blur-(5,5) norm-1 objective mismatch on macOS).
+2. If an issue matches, append a row to its "Occurrences" table (date, branch or PR with short SHA,
+   linked job name) and add a comment with the specifics: job link, observed vs expected values or
+   crash site, dependency versions from the log. Update the issue title if the new occurrence
+   invalidates a qualifier in it (for example, a Julia version or OS that no longer holds).
+3. If nothing matches, open a new issue titled "Flaky CI: <signature>" with the failure details,
+   versions, a job link, and an "Occurrences" table ending with "Append new occurrences to this
+   table."
+4. Rerun only the failed jobs: `gh run rerun <run-id> --failed` (the run must be completed first).
+   If the same leg fails twice in a row on one PR, stop rerunning and report it — repetition
+   suggests a real regression, not flake.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,17 +8,15 @@ code or config the PR touches is not flake — debug it instead.
 For failures unrelated to the PR's changes:
 
 1. Search open issues titled "Flaky CI" for a matching signature (failing test case, error type,
-   crash stack site). Known trackers: #218 (intermittent HiGHS segfault during the test suite), #219
-   (blur-(5,5) norm-1 objective mismatch on macOS).
-2. If an issue matches, append a row to its "Occurrences" table (date, branch or PR with short SHA,
-   linked job name) and add a comment with the specifics: job link, observed vs expected values or
-   crash site, dependency versions from the log. Update the issue title if the new occurrence
-   invalidates a qualifier in it (for example, a Julia version or OS that no longer holds). Read the
-   resolved versions from the job log rather than from the check name — the "1" and "1.12" matrix
-   selectors can resolve to the same Julia version.
-3. If nothing matches, open a new issue titled "Flaky CI: <signature>" with the failure details,
-   versions, a job link, and an "Occurrences" table ending with "Append new occurrences to this
-   table."
-4. Rerun only the failed jobs: `gh run rerun <run-id> --failed` (the run must be completed first).
-   If the same leg fails twice in a row on one PR, stop rerunning and report it — repetition
+   crash stack site). Read resolved versions from the job log rather than from the check name —
+   distinct matrix selectors can resolve to the same underlying version.
+2. If an issue matches, the failure is a known flake. Append a row to its "Occurrences" table (date,
+   branch or PR with short SHA, linked job name), add a comment with the specifics — job link,
+   observed vs expected values or crash site, dependency versions from the log — and update the
+   issue title if the new occurrence invalidates a qualifier in it. Then rerun the failed jobs.
+3. If nothing matches, rerun first: `gh run rerun <run-id> --failed` (the run must be completed).
+   Only a passing rerun verifies the failure as flake — then open a new issue titled "Flaky CI:
+   <signature>" with the failure details, versions, a job link, and an "Occurrences" table ending
+   with "Append new occurrences to this table."
+4. If the same leg fails twice in a row on one PR, stop rerunning and report it — repetition
    suggests a real regression, not flake.


### PR DESCRIPTION
## Why

Flaky CI failures unrelated to a PR's changes recur intermittently (issues #218, #219). Without a written procedure, each failure gets triaged ad hoc, so occurrences go unrecorded and stale qualifiers linger on the tracking issues. This documents the triage workflow so it is applied consistently.

## What

Adds one new `CLAUDE.md` section, "Flaky CI failures": classify the failure from the log before rerunning, match it against open "Flaky CI" issues, record the occurrence (or open a new issue) and retitle when a qualifier no longer holds, then rerun only the failed jobs. No code or workflow changes.

Formatting was applied with the repo's pinned prettier (`npx prettier@3.9.5 --write`), so the file passes the CI prettier check.