### PR TITLE
Cut 0.8.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MIPVerify"
 uuid = "e5e5f8be-2a6a-5994-adbb-5afbd0e30425"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Vincent Tjeng"]
 
 [workspace]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,7 @@ macOS, and 64-bit Linux, but example code in this README is for Linux.
 
 #### Installing Julia
 
-The latest release of this package requires version 1.6 or above of Julia. See
+The latest release of this package requires version 1.12 or above of Julia. See
 [installation instructions](https://julialang.org/downloads/). To complete your installation, ensure
 that you are able to call `julia` REPL from the command line.
 


### PR DESCRIPTION
## Summary

- Bump the package version from 0.7.0 to 0.8.0.
- Correct the installation docs to state the existing Julia 1.12 minimum.

## Why

`master` has accumulated user-facing features since 0.7.0, including the feasibility objective, independently verified witnesses, and optional verification statistics. It also now requires JuMP 1.1+ and MathOptInterface 1.x, so a minor pre-1.0 version bump is appropriate.

The installation page still said Julia 1.6 even though `Project.toml` has required Julia 1.12 since the previous release.

## Impact

After this PR is merged and registered, users will be able to install MIPVerify 0.8.0 with documentation that matches its package compatibility bounds.

## Validation

- Parsed the project with Julia and verified `Pkg.project().version == v"0.8.0"`.
- Ran `git diff --check`.
- [GitHub Actions run 29634367712](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29634367712) passed all checks: the six Julia/OS package-test legs, documentation, notebooks, formatting and linting, benchmark helpers and analysis, workflow linting, and Codecov.

_AI collaboration: co-produced with Codex (OpenAI)._