### PR TITLE
Add MIPVerify release skill

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -1,38 +1,65 @@
 ---
 name: cut-release
-description: Prepare and cut MIPVerify.jl releases from version selection through release-note drafting, the release pull request, JuliaRegistrator, the General registry, TagBot, and final verification. Use when asked to draft or revise MIPVerify release notes, bump the package version, open or merge a release PR, register a new version, monitor release automation, or verify a completed release.
+description:
+  Prepare and cut MIPVerify.jl releases from version selection through release-note drafting, the
+  release pull request, JuliaRegistrator, the General registry, TagBot, and final verification. Use
+  when asked to draft or revise MIPVerify release notes, bump the package version, open or merge a
+  release PR, register a new version, monitor release automation, or verify a completed release.
 ---
 
 # Cut a MIPVerify release
 
-Run the release as a sequence of independently verified gates. Keep the release commit small, give the release notes the same care as code, and follow the automation through the registry merge and published GitHub release.
+Run the release as a sequence of independently verified gates. Keep the release commit small, give
+the release notes the same care as code, and follow the automation through the registry merge and
+published GitHub release.
 
-Before drafting or approving release notes, read [references/release-notes-style.md](references/release-notes-style.md) completely.
+Before drafting or approving release notes, read
+[references/release-notes-style.md](references/release-notes-style.md) completely.
 
 ## Guardrails
 
 - Read and follow the repository `AGENTS.md` and shared instructions.
-- Run `gh auth status` outside the sandbox before using GitHub. Do not diagnose credentials from a sandboxed check.
+- Run `gh auth status` outside the sandbox before using GitHub. Do not diagnose credentials from a
+  sandboxed check.
 - Work on a descriptive branch from current `origin/master`. Never commit directly on `master`.
-- Preserve unrelated user changes. If the current worktree is dirty, use a clean throwaway worktree or clone instead of stashing, reverting, or mixing changes.
-- Treat the release PR merge, Julia registration, General registry merge, tag, and GitHub release as separate gates. Verify each gate before starting the next one.
-- Post the JuliaRegistrator request on the merged release commit, not on the release PR or its pre-merge head.
-- Let General's automerge and this repository's TagBot workflow operate normally. Do not manually merge the registry PR or create a tag while automation is healthy.
-- Preserve every required AI trailer and visible disclosure from the repository instructions. The Registrator commit comment is its own GitHub artifact and needs its own disclosure.
+- Preserve unrelated user changes. If the current worktree is dirty, use a clean throwaway worktree
+  or clone instead of stashing, reverting, or mixing changes.
+- Treat the release PR merge, Julia registration, General registry merge, tag, and GitHub release as
+  separate gates. Verify each gate before starting the next one.
+- Post the JuliaRegistrator request on the merged release commit, not on the release PR or its
+  pre-merge head.
+- Let General's automerge and this repository's TagBot workflow operate normally. Do not manually
+  merge the registry PR or create a tag while automation is healthy.
+- Preserve every required AI trailer and visible disclosure from the repository instructions. The
+  Registrator commit comment is its own GitHub artifact and needs its own disclosure.
 
 ## 1. Reconcile the current release state
 
-Start by locating any release work that already exists: an open or merged release PR, a version bump on `master`, a Registrator comment, a General PR, a tag, and a GitHub release. Compare their versions and commit SHAs before making changes.
+Start by locating any release work that already exists: an open or merged release PR, a version bump
+on `master`, a Registrator comment, a General PR, a tag, and a GitHub release. Compare their
+versions and commit SHAs before making changes.
 
-Resume from the first incomplete gate and perform only the gates the user authorized. Do not infer the next version solely from `Project.toml`: it may already have been bumped for a release that has not been tagged. Reuse verified artifacts instead of opening a duplicate PR, posting a second registration request, or creating a competing tag or release.
+Resume from the first incomplete gate and perform only the gates the user authorized. Do not infer
+the next version solely from `Project.toml`: it may already have been bumped for a release that has
+not been tagged. Reuse verified artifacts instead of opening a duplicate PR, posting a second
+registration request, or creating a competing tag or release.
 
 ## 2. Establish the release range and version
 
-1. Fetch `origin/master` and inspect the live repository, latest tag, latest GitHub release, and `Project.toml` version.
-2. Build a complete inventory of changes since the latest release tag from every first-parent commit. Attach PR metadata where a commit came from a PR, and retain direct commits as first-class inventory entries. Resolve squash-merge subjects such as `... (#123)` back to their PRs.
-3. Inspect `Project.toml` compatibility and search README/docs for version requirements that may have become stale.
-4. Choose the next version from the current version and actual changes. While the package is pre-1.0, user-visible breaking changes normally require a minor release and compatible fixes normally require a patch release; apply normal semantic-versioning rules after 1.0. Ask only when the change set leaves the choice genuinely ambiguous.
-5. Keep feature work out of the release PR. Limit it to release metadata and small, clearly justified release-facing corrections.
+1. Fetch `origin/master` and inspect the live repository, latest tag, latest GitHub release, and
+   `Project.toml` version.
+2. Build a complete inventory of changes since the latest release tag from every first-parent
+   commit. Attach PR metadata where a commit came from a PR, and retain direct commits as
+   first-class inventory entries. Resolve squash-merge subjects such as `... (#123)` back to their
+   PRs.
+3. Inspect `Project.toml` compatibility and search README/docs for version requirements that may
+   have become stale.
+4. Choose the next version from the current version and actual changes. While the package is
+   pre-1.0, user-visible breaking changes normally require a minor release and compatible fixes
+   normally require a patch release; apply normal semantic-versioning rules after 1.0. Ask only when
+   the change set leaves the choice genuinely ambiguous.
+5. Keep feature work out of the release PR. Limit it to release metadata and small, clearly
+   justified release-facing corrections.
 
 Useful read-only starting points include:
 
@@ -44,7 +71,10 @@ gh pr view <number> --repo vtjeng/MIPVerify.jl --json title,body,commits,files,u
 
 ## 3. Research the release changes
 
-Research every inventory entry against its committed diff, implementation, tests, commit history, and any linked evidence. Use subagents when parallel review materially improves coverage: give substantive changes focused ownership, batch trivial related changes when appropriate, and work in waves when concurrency is limited. Do not ask research subagents to edit files or GitHub.
+Research every inventory entry against its committed diff, implementation, tests, commit history,
+and any linked evidence. Use subagents when parallel review materially improves coverage: give
+substantive changes focused ownership, batch trivial related changes when appropriate, and work in
+waves when concurrency is limited. Do not ask research subagents to edit files or GitHub.
 
 Require a compact result with:
 
@@ -56,26 +86,35 @@ Require a compact result with:
 - proposed release-note section and source mapping;
 - exact claims that need an independent accuracy check.
 
-Maintain the complete change inventory even when several entries become one bullet. Mark purely internal housekeeping as intentionally omitted rather than losing track of it.
+Maintain the complete change inventory even when several entries become one bullet. Mark purely
+internal housekeeping as intentionally omitted rather than losing track of it.
 
 ## 4. Draft and verify the release notes
 
 1. Read the release-note style reference linked above.
-2. Review recent successful releases for tone and level of detail, then choose the closest precedent. Treat examples as evidence of style, not fixed templates.
-3. Group PRs only when they serve the same user-facing goal. When one bullet contains distinct changes, map each PR to its change in the opening sentence.
-4. Choose sentence-case sections from the purposes represented in the current release. Omit empty sections and do not preserve an old release's structure when it no longer fits.
-5. Scale review depth to the release. Independently check risky correctness, compatibility, and performance claims against code and evidence; for a substantial release, also use focused passes for coverage, placement, and readability.
+2. Review recent successful releases for tone and level of detail, then choose the closest
+   precedent. Treat examples as evidence of style, not fixed templates.
+3. Group PRs only when they serve the same user-facing goal. When one bullet contains distinct
+   changes, map each PR to its change in the opening sentence.
+4. Choose sentence-case sections from the purposes represented in the current release. Omit empty
+   sections and do not preserve an old release's structure when it no longer fits.
+5. Scale review depth to the release. Independently check risky correctness, compatibility, and
+   performance claims against code and evidence; for a substantial release, also use focused passes
+   for coverage, placement, and readability.
 6. Resolve every finding and show the complete copy-ready draft to the user before posting it.
 7. End the Registrator comment with the repository's visible AI collaboration disclosure.
 
-Do not let a concise rewrite weaken a safety claim, merge separate benchmark experiments, or imply that unrelated work shares one goal.
-If a material fact remains unverified, omit the claim from the copy-ready notes or keep the draft explicitly blocked; do not publish provisional wording as fact.
+Do not let a concise rewrite weaken a safety claim, merge separate benchmark experiments, or imply
+that unrelated work shares one goal. If a material fact remains unverified, omit the claim from the
+copy-ready notes or keep the draft explicitly blocked; do not publish provisional wording as fact.
 
 ## 5. Create and validate the release PR
 
-1. Create a branch named like `agent/cut-<version>` from current `origin/master` in a clean worktree.
+1. Create a branch named like `agent/cut-<version>` from current `origin/master` in a clean
+   worktree.
 2. Bump `version` in `Project.toml`.
-3. Correct stale release-facing documentation only after checking it against `[compat]`; do not change compatibility merely to match prose.
+3. Correct stale release-facing documentation only after checking it against `[compat]`; do not
+   change compatibility merely to match prose.
 4. Inspect the full diff and verify the package version with Julia:
 
 ```console
@@ -84,15 +123,21 @@ git diff --check
 ```
 
 5. Run proportionate local checks, then rely on the full pull-request matrix before merge.
-6. Commit as `Cut <version>` with the required `Assisted-by` trailer, push the branch, and open a draft PR titled `Cut <version>` with the visible disclosure.
-7. Record the exact head SHA and CI run. Require every check expected by the current workflows and branch protection to pass; do not rely on an old release's check list.
+6. Commit as `Cut <version>` with the required `Assisted-by` trailer, push the branch, and open a
+   draft PR titled `Cut <version>` with the visible disclosure.
+7. Record the exact head SHA and CI run. Require every check expected by the current workflows and
+   branch protection to pass; do not rely on an old release's check list.
 
 ## 6. Merge the release PR
 
-1. Reconfirm that the PR diff contains only the intended version/documentation changes, the head SHA has not changed, all checks pass, and the approved release notes still match the code being released.
+1. Reconfirm that the PR diff contains only the intended version/documentation changes, the head SHA
+   has not changed, all checks pass, and the approved release notes still match the code being
+   released.
 2. Mark the PR ready.
-3. Squash-merge it to match repository precedent. Use the final subject `Cut <version> (#<pr>)` and explicitly preserve applicable AI trailers in the squash body.
-4. Resolve the resulting `master` commit SHA from the merged PR. Do not assume it equals the branch head.
+3. Squash-merge it to match repository precedent. Use the final subject `Cut <version> (#<pr>)` and
+   explicitly preserve applicable AI trailers in the squash body.
+4. Resolve the resulting `master` commit SHA from the merged PR. Do not assume it equals the branch
+   head.
 5. Verify on that exact commit:
    - `Project.toml` contains the intended version;
    - any documentation correction is present;
@@ -101,7 +146,9 @@ git diff --check
 
 ## 7. Register the merged commit
 
-Put the approved text in a temporary file and post it as a commit comment on the verified merge SHA. Preserve newlines and Markdown by reading the file through `gh api` rather than embedding a large shell string.
+Put the approved text in a temporary file and post it as a commit comment on the verified merge SHA.
+Preserve newlines and Markdown by reading the file through `gh api` rather than embedding a large
+shell string.
 
 ```console
 gh api --method POST repos/vtjeng/MIPVerify.jl/commits/<merge-sha>/comments \
@@ -116,25 +163,36 @@ The file must begin exactly:
 Release notes:
 ```
 
-Verify the returned comment URL and body. Wait for JuliaRegistrator to reply with the `JuliaRegistries/General` PR before doing anything else. Do not repost while the bot is merely pending.
+Verify the returned comment URL and body. Wait for JuliaRegistrator to reply with the
+`JuliaRegistries/General` PR before doing anything else. Do not repost while the bot is merely
+pending.
 
 ## 8. Monitor registration and publication
 
-1. Open the General PR and confirm its version, source commit, and embedded release notes match the approved release.
-2. Watch registry-consistency and automerge checks. A blocked or pending state can reflect a normal queue or automerge gate, so inspect the checks and bot comments before treating it as a failure.
+1. Open the General PR and confirm its version, source commit, and embedded release notes match the
+   approved release.
+2. Watch registry-consistency and automerge checks. A blocked or pending state can reflect a normal
+   queue or automerge gate, so inspect the checks and bot comments before treating it as a failure.
 3. Wait for the General PR to merge. Do not merge it manually.
-4. Confirm `.github/workflows/TagBot.yml` is present and wait for TagBot to create `v<version>` and the GitHub release.
+4. Confirm `.github/workflows/TagBot.yml` is present and wait for TagBot to create `v<version>` and
+   the GitHub release.
 5. Verify:
    - the General PR is merged;
    - the tag peels to the exact release merge commit;
    - the GitHub release exists at the expected tag;
-   - the rendered release notes preserve the approved headings, bullets, PR references, and disclosure.
-6. Report the release PR, merge commit, Registrator comment, General PR, tag, and GitHub release links.
+   - the rendered release notes preserve the approved headings, bullets, PR references, and
+     disclosure.
+6. Report the release PR, merge commit, Registrator comment, General PR, tag, and GitHub release
+   links.
 
 ## Failure handling
 
 - If a source PR check fails, inspect and fix it before merging; never register a red commit.
-- If JuliaRegistrator reports an error, diagnose the exact version, commit, or metadata problem before posting another request.
-- If a General check fails, report the failing check and evidence. Do not mutate the registry PR unless the user explicitly expands the task.
-- If TagBot does not run after the General merge, inspect the workflow and recent runs first. Ask before manually dispatching TagBot or creating a tag.
-- Never create a second Registrator comment, registry PR, tag, or release merely because automation is slow.
+- If JuliaRegistrator reports an error, diagnose the exact version, commit, or metadata problem
+  before posting another request.
+- If a General check fails, report the failing check and evidence. Do not mutate the registry PR
+  unless the user explicitly expands the task.
+- If TagBot does not run after the General merge, inspect the workflow and recent runs first. Ask
+  before manually dispatching TagBot or creating a tag.
+- Never create a second Registrator comment, registry PR, tag, or release merely because automation
+  is slow.

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: cut-release
+description: Prepare and cut MIPVerify.jl releases from version selection through release-note drafting, the release pull request, JuliaRegistrator, the General registry, TagBot, and final verification. Use when asked to draft or revise MIPVerify release notes, bump the package version, open or merge a release PR, register a new version, monitor release automation, or verify a completed release.
+---
+
+# Cut a MIPVerify release
+
+Run the release as a sequence of independently verified gates. Keep the release commit small, give the release notes the same care as code, and follow the automation through the registry merge and published GitHub release.
+
+Before drafting or approving release notes, read [references/release-notes-style.md](references/release-notes-style.md) completely.
+
+## Guardrails
+
+- Read and follow the repository `AGENTS.md` and shared instructions.
+- Run `gh auth status` outside the sandbox before using GitHub. Do not diagnose credentials from a sandboxed check.
+- Work on a descriptive branch from current `origin/master`. Never commit directly on `master`.
+- Preserve unrelated user changes. If the current worktree is dirty, use a clean throwaway worktree or clone instead of stashing, reverting, or mixing changes.
+- Treat the release PR merge, Julia registration, General registry merge, tag, and GitHub release as separate gates. Verify each gate before starting the next one.
+- Post the JuliaRegistrator request on the merged release commit, not on the release PR or its pre-merge head.
+- Let General's automerge and this repository's TagBot workflow operate normally. Do not manually merge the registry PR or create a tag while automation is healthy.
+- Preserve every required AI trailer and visible disclosure from the repository instructions. The Registrator commit comment is its own GitHub artifact and needs its own disclosure.
+
+## 1. Reconcile the current release state
+
+Start by locating any release work that already exists: an open or merged release PR, a version bump on `master`, a Registrator comment, a General PR, a tag, and a GitHub release. Compare their versions and commit SHAs before making changes.
+
+Resume from the first incomplete gate and perform only the gates the user authorized. Do not infer the next version solely from `Project.toml`: it may already have been bumped for a release that has not been tagged. Reuse verified artifacts instead of opening a duplicate PR, posting a second registration request, or creating a competing tag or release.
+
+## 2. Establish the release range and version
+
+1. Fetch `origin/master` and inspect the live repository, latest tag, latest GitHub release, and `Project.toml` version.
+2. Build a complete inventory of changes since the latest release tag from every first-parent commit. Attach PR metadata where a commit came from a PR, and retain direct commits as first-class inventory entries. Resolve squash-merge subjects such as `... (#123)` back to their PRs.
+3. Inspect `Project.toml` compatibility and search README/docs for version requirements that may have become stale.
+4. Choose the next version from the current version and actual changes. While the package is pre-1.0, user-visible breaking changes normally require a minor release and compatible fixes normally require a patch release; apply normal semantic-versioning rules after 1.0. Ask only when the change set leaves the choice genuinely ambiguous.
+5. Keep feature work out of the release PR. Limit it to release metadata and small, clearly justified release-facing corrections.
+
+Useful read-only starting points include:
+
+```console
+git log --first-parent --oneline <previous-tag>..origin/master
+gh release view <previous-tag> --repo vtjeng/MIPVerify.jl
+gh pr view <number> --repo vtjeng/MIPVerify.jl --json title,body,commits,files,url
+```
+
+## 3. Research the release changes
+
+Research every inventory entry against its committed diff, implementation, tests, commit history, and any linked evidence. Use subagents when parallel review materially improves coverage: give substantive changes focused ownership, batch trivial related changes when appropriate, and work in waves when concurrency is limited. Do not ask research subagents to edit files or GitHub.
+
+Require a compact result with:
+
+- purpose and user-facing outcome;
+- behavior, compatibility, or schema changes;
+- correctness and failure-mode implications;
+- performance evidence when relevant, including the scope needed to interpret a publishable claim;
+- tests, CI, dependency, or maintainer-only scope;
+- proposed release-note section and source mapping;
+- exact claims that need an independent accuracy check.
+
+Maintain the complete change inventory even when several entries become one bullet. Mark purely internal housekeeping as intentionally omitted rather than losing track of it.
+
+## 4. Draft and verify the release notes
+
+1. Read the release-note style reference linked above.
+2. Review recent successful releases for tone and level of detail, then choose the closest precedent. Treat examples as evidence of style, not fixed templates.
+3. Group PRs only when they serve the same user-facing goal. When one bullet contains distinct changes, map each PR to its change in the opening sentence.
+4. Choose sentence-case sections from the purposes represented in the current release. Omit empty sections and do not preserve an old release's structure when it no longer fits.
+5. Scale review depth to the release. Independently check risky correctness, compatibility, and performance claims against code and evidence; for a substantial release, also use focused passes for coverage, placement, and readability.
+6. Resolve every finding and show the complete copy-ready draft to the user before posting it.
+7. End the Registrator comment with the repository's visible AI collaboration disclosure.
+
+Do not let a concise rewrite weaken a safety claim, merge separate benchmark experiments, or imply that unrelated work shares one goal.
+If a material fact remains unverified, omit the claim from the copy-ready notes or keep the draft explicitly blocked; do not publish provisional wording as fact.
+
+## 5. Create and validate the release PR
+
+1. Create a branch named like `agent/cut-<version>` from current `origin/master` in a clean worktree.
+2. Bump `version` in `Project.toml`.
+3. Correct stale release-facing documentation only after checking it against `[compat]`; do not change compatibility merely to match prose.
+4. Inspect the full diff and verify the package version with Julia:
+
+```console
+julia --project -e 'using Pkg; println(Pkg.project().version)'
+git diff --check
+```
+
+5. Run proportionate local checks, then rely on the full pull-request matrix before merge.
+6. Commit as `Cut <version>` with the required `Assisted-by` trailer, push the branch, and open a draft PR titled `Cut <version>` with the visible disclosure.
+7. Record the exact head SHA and CI run. Require every check expected by the current workflows and branch protection to pass; do not rely on an old release's check list.
+
+## 6. Merge the release PR
+
+1. Reconfirm that the PR diff contains only the intended version/documentation changes, the head SHA has not changed, all checks pass, and the approved release notes still match the code being released.
+2. Mark the PR ready.
+3. Squash-merge it to match repository precedent. Use the final subject `Cut <version> (#<pr>)` and explicitly preserve applicable AI trailers in the squash body.
+4. Resolve the resulting `master` commit SHA from the merged PR. Do not assume it equals the branch head.
+5. Verify on that exact commit:
+   - `Project.toml` contains the intended version;
+   - any documentation correction is present;
+   - the commit subject and trailers are correct;
+   - the changed-file list is still the expected release diff.
+
+## 7. Register the merged commit
+
+Put the approved text in a temporary file and post it as a commit comment on the verified merge SHA. Preserve newlines and Markdown by reading the file through `gh api` rather than embedding a large shell string.
+
+```console
+gh api --method POST repos/vtjeng/MIPVerify.jl/commits/<merge-sha>/comments \
+  -F body=@<release-notes-file>
+```
+
+The file must begin exactly:
+
+```markdown
+@JuliaRegistrator register
+
+Release notes:
+```
+
+Verify the returned comment URL and body. Wait for JuliaRegistrator to reply with the `JuliaRegistries/General` PR before doing anything else. Do not repost while the bot is merely pending.
+
+## 8. Monitor registration and publication
+
+1. Open the General PR and confirm its version, source commit, and embedded release notes match the approved release.
+2. Watch registry-consistency and automerge checks. A blocked or pending state can reflect a normal queue or automerge gate, so inspect the checks and bot comments before treating it as a failure.
+3. Wait for the General PR to merge. Do not merge it manually.
+4. Confirm `.github/workflows/TagBot.yml` is present and wait for TagBot to create `v<version>` and the GitHub release.
+5. Verify:
+   - the General PR is merged;
+   - the tag peels to the exact release merge commit;
+   - the GitHub release exists at the expected tag;
+   - the rendered release notes preserve the approved headings, bullets, PR references, and disclosure.
+6. Report the release PR, merge commit, Registrator comment, General PR, tag, and GitHub release links.
+
+## Failure handling
+
+- If a source PR check fails, inspect and fix it before merging; never register a red commit.
+- If JuliaRegistrator reports an error, diagnose the exact version, commit, or metadata problem before posting another request.
+- If a General check fails, report the failing check and evidence. Do not mutate the registry PR unless the user explicitly expands the task.
+- If TagBot does not run after the General merge, inspect the workflow and recent runs first. Ask before manually dispatching TagBot or creating a tag.
+- Never create a second Registrator comment, registry PR, tag, or release merely because automation is slow.

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -26,8 +26,8 @@ Before drafting or approving release notes, read
   or clone instead of stashing, reverting, or mixing changes.
 - Treat the release PR merge, Julia registration, General registry merge, tag, and GitHub release as
   separate gates. Verify each gate before starting the next one.
-- Post the JuliaRegistrator request on the merged release commit, not on the release PR or its
-  pre-merge head.
+- Wait for the release PR to merge, resolve its merge commit, and post the JuliaRegistrator request
+  on that commit.
 - Let General's automerge and this repository's TagBot workflow operate normally. Do not manually
   merge the registry PR or create a tag while automation is healthy.
 - Preserve every required AI trailer and visible disclosure from the repository instructions. The
@@ -37,7 +37,7 @@ Before drafting or approving release notes, read
 
 Start by locating any release work that already exists: an open or merged release PR, a version bump
 on `master`, a Registrator comment, a General PR, a tag, and a GitHub release. Compare their
-versions and commit SHAs before making changes.
+versions and commit IDs (SHAs) before making changes.
 
 Resume from the first incomplete gate and perform only the gates the user authorized. Do not infer
 the next version solely from `Project.toml`: it may already have been bumped for a release that has
@@ -49,15 +49,14 @@ registration request, or creating a competing tag or release.
 1. Fetch `origin/master` and inspect the live repository, latest tag, latest GitHub release, and
    `Project.toml` version.
 2. Build a complete inventory of changes since the latest release tag from every first-parent
-   commit. Attach PR metadata where a commit came from a PR, and retain direct commits as
-   first-class inventory entries. Resolve squash-merge subjects such as `... (#123)` back to their
-   PRs.
+   commit. Attach PR metadata where a commit came from a PR, and retain direct commits as separate
+   inventory entries. Resolve squash-merge subjects such as `... (#123)` back to their PRs.
 3. Inspect `Project.toml` compatibility and search README/docs for version requirements that may
    have become stale.
-4. Choose the next version from the current version and actual changes. While the package is
-   pre-1.0, user-visible breaking changes normally require a minor release and compatible fixes
-   normally require a patch release; apply normal semantic-versioning rules after 1.0. Ask only when
-   the change set leaves the choice genuinely ambiguous.
+4. Choose the next version from the current version and actual changes. Before 1.0, user-visible
+   breaking changes and new user-visible functionality normally require a minor release; compatible
+   bug fixes normally require a patch release. Apply normal semantic-versioning rules after 1.0. Ask
+   only when the change set leaves the choice genuinely ambiguous.
 5. Keep feature work out of the release PR. Limit it to release metadata and small, clearly
    justified release-facing corrections.
 
@@ -82,18 +81,18 @@ Require a compact result with:
 - behavior, compatibility, or schema changes;
 - correctness and failure-mode implications;
 - performance evidence when relevant, including the scope needed to interpret a publishable claim;
-- tests, CI, dependency, or maintainer-only scope;
-- proposed release-note section and source mapping;
+- tests, continuous integration (CI), dependency, or maintainer-only scope;
+- proposed release-note section and the inventory entries it represents;
 - exact claims that need an independent accuracy check.
 
-Maintain the complete change inventory even when several entries become one bullet. Mark purely
-internal housekeeping as intentionally omitted rather than losing track of it.
+Maintain the complete change inventory even when several entries become one bullet. Retain purely
+internal housekeeping in the inventory and mark it as intentionally omitted from the notes.
 
 ## 4. Draft and verify the release notes
 
 1. Read the release-note style reference linked above.
-2. Review recent successful releases for tone and level of detail, then choose the closest
-   precedent. Treat examples as evidence of style, not fixed templates.
+2. Review recent successful releases, then choose the closest precedent for tone and level of
+   detail.
 3. Group PRs only when they serve the same user-facing goal. When one bullet contains distinct
    changes, map each PR to its change in the opening sentence.
 4. Choose sentence-case sections from the purposes represented in the current release. Omit empty
@@ -105,8 +104,9 @@ internal housekeeping as intentionally omitted rather than losing track of it.
 7. End the Registrator comment with the repository's visible AI collaboration disclosure.
 
 Do not let a concise rewrite weaken a safety claim, merge separate benchmark experiments, or imply
-that unrelated work shares one goal. If a material fact remains unverified, omit the claim from the
-copy-ready notes or keep the draft explicitly blocked; do not publish provisional wording as fact.
+that unrelated work shares one goal. If removing an unverified claim leaves an accurate, useful
+bullet, omit the claim. Otherwise keep the draft explicitly blocked. Never publish provisional
+wording as fact.
 
 ## 5. Create and validate the release PR
 
@@ -122,7 +122,7 @@ julia --project -e 'using Pkg; println(Pkg.project().version)'
 git diff --check
 ```
 
-5. Run proportionate local checks, then rely on the full pull-request matrix before merge.
+5. Run proportionate local checks, then rely on the full set of pull-request checks before merge.
 6. Commit as `Cut <version>` with the required `Assisted-by` trailer, push the branch, and open a
    draft PR titled `Cut <version>` with the visible disclosure.
 7. Record the exact head SHA and CI run. Require every check expected by the current workflows and
@@ -147,8 +147,7 @@ git diff --check
 ## 7. Register the merged commit
 
 Put the approved text in a temporary file and post it as a commit comment on the verified merge SHA.
-Preserve newlines and Markdown by reading the file through `gh api` rather than embedding a large
-shell string.
+Read the file through `gh api` to preserve newlines and Markdown.
 
 ```console
 gh api --method POST repos/vtjeng/MIPVerify.jl/commits/<merge-sha>/comments \
@@ -164,7 +163,7 @@ Release notes:
 ```
 
 Verify the returned comment URL and body. Wait for JuliaRegistrator to reply with the
-`JuliaRegistries/General` PR before doing anything else. Do not repost while the bot is merely
+`JuliaRegistries/General` PR before advancing to registry monitoring. Do not repost while the bot is
 pending.
 
 ## 8. Monitor registration and publication
@@ -178,7 +177,7 @@ pending.
    the GitHub release.
 5. Verify:
    - the General PR is merged;
-   - the tag peels to the exact release merge commit;
+   - the tag resolves to the exact release merge commit;
    - the GitHub release exists at the expected tag;
    - the rendered release notes preserve the approved headings, bullets, PR references, and
      disclosure.
@@ -187,7 +186,8 @@ pending.
 
 ## Failure handling
 
-- If a source PR check fails, inspect and fix it before merging; never register a red commit.
+- If a required release PR check fails, inspect and fix the failure before merging. Register only
+  after all required release PR checks pass.
 - If JuliaRegistrator reports an error, diagnose the exact version, commit, or metadata problem
   before posting another request.
 - If a General check fails, report the failing check and evidence. Do not mutate the registry PR

--- a/.agents/skills/cut-release/agents/openai.yaml
+++ b/.agents/skills/cut-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Cut MIPVerify Release"
+  short_description: "Prepare, register, and verify MIPVerify releases"
+  default_prompt: "Use $cut-release to prepare, register, and verify the next MIPVerify release."

--- a/.agents/skills/cut-release/references/release-notes-style.md
+++ b/.agents/skills/cut-release/references/release-notes-style.md
@@ -37,10 +37,10 @@ clearer.
 
 ## Introduce terms, actors, and scope
 
-- Define unfamiliar domain terms before using their shorthand or result-field names.
+- Define unfamiliar domain terms before using their shorthand or the names of related result fields.
 - Expand acronyms on first use unless they are already established in the notes.
-- Name the affected command, test set, workflow, API, or user group. Avoid vague labels whose actor
-  or scope is unclear.
+- Name the affected command, test set, workflow, programming interface, or user group. Avoid vague
+  labels whose actor or scope is unclear.
 - Put limiting words such as `only` next to the thing they limit.
 - Prefer plain descriptions to internal metric, schema, or implementation labels when the public
   meaning is the same.
@@ -53,9 +53,8 @@ Apply the detailed checks below when the release makes correctness or solver-res
   reported by a solver or another external system.
 - Use `certified`, `proven`, and similar terms only when the implementation supports that exact
   guarantee.
-- Keep soundness and numerical strength conceptually separate. If a valid result can also become
-  narrower or stronger, explain the safeguard without making conservative and tighter sound
-  contradictory.
+- Separate soundness (whether a result is valid) from numerical strength (how narrow or tight it
+  is). A result can be both conservative and tighter, so explain each effect separately.
 - Preserve assumptions and caveats for negative results, fallbacks, timeouts, nonfinite values, and
   partial solutions.
 - Inspect every relevant execution path before turning a fallback into an absolute statement.
@@ -71,11 +70,12 @@ When the notes include measured performance claims:
   the result.
 - Say explicitly when measurements came from separate runs.
 - Map every number to the change and metric it supports.
-- Preserve comparable-sample conditions when totals exclude some cases.
+- When totals exclude cases, state which cases were included and compare totals over the same case
+  set.
 - Prefer familiar aggregate terms and short phrases over internal report labels or stacked
   modifiers.
 - Use enough precision to support the claim without carrying unnecessary digits into prose.
-- Report measurements as evidence from the measured setup, not as universal performance guarantees.
+- Limit performance claims to the measured setup and avoid universal guarantees.
 
 ## Cut detail that does not help release readers
 
@@ -83,9 +83,9 @@ When the notes include measured performance claims:
   implementation detail.
 - Summarize routine operational defenses as safety or publishing safeguards unless a specific guard
   changes how readers use the tool.
-- Omit implementation seams, internal refactors, and maintainer-only housekeeping unless they
-  materially affect supported use or contribution workflow.
-- Keep a private change inventory so every omission is deliberate.
+- Omit low-level implementation details, internal refactors, and maintainer-only housekeeping unless
+  they materially affect supported use or contribution workflow.
+- Keep a working change inventory so every omission is deliberate.
 - Remove redundant modifiers, repeated requirements, and phrases that restate a heading.
 - Prefer one clear sentence to a list of low-level safeguards or schema fields.
 

--- a/.agents/skills/cut-release/references/release-notes-style.md
+++ b/.agents/skills/cut-release/references/release-notes-style.md
@@ -1,0 +1,101 @@
+# MIPVerify release-note style
+
+Use these rules when drafting, revising, or approving release notes. Prefer the shortest wording that preserves the user-visible behavior, compatibility boundary, safety caveat, and measurement scope.
+
+## Lead with the purpose
+
+Start each bullet with what the release accomplishes. Put mechanisms and evidence after the goal.
+
+Useful patterns include:
+
+- `<Outcome>: #<pr> changes <mechanism>, while #<pr> changes <other mechanism>.`
+- `<Goal> by <essential mechanism>.`
+- `<User-visible change>. <Important scope, migration, or evidence>.`
+
+Avoid opening with a PR number, schema operation, or implementation detail when the reader first needs the reason for the change.
+
+When a bullet combines distinct PRs, map each PR to its change in the first sentence. Do not make readers reconstruct that mapping from the references at the end.
+
+## Organize by purpose
+
+- Combine PRs only when they contribute to one reader-facing outcome.
+- Split changes that merely share a file, workflow, dependency, or implementation area.
+- Split a single PR across bullets when it contains changes with different purposes.
+- Place a change according to what it means to users: compatibility, behavior, correctness, performance, tooling, tests, CI, or maintenance.
+- Distinguish public breaking changes from versioned internal artifacts used only by repository tooling.
+
+Possible section names include `Breaking changes`, `New features`, `Correctness and performance`, `Benchmark tooling`, `Examples, tests, and CI`, and `Dependency compatibility`. Use only the sections justified by the current release. Rename or split them when that makes the grouping clearer.
+
+## Introduce terms, actors, and scope
+
+- Define unfamiliar domain terms before using their shorthand or result-field names.
+- Expand acronyms on first use unless they are already established in the notes.
+- Name the affected command, test set, workflow, API, or user group. Avoid vague labels whose actor or scope is unclear.
+- Put limiting words such as `only` next to the thing they limit.
+- Prefer plain descriptions to internal metric, schema, or implementation labels when the public meaning is the same.
+
+## Calibrate technical claims
+
+Apply the detailed checks below when the release makes correctness or solver-result claims:
+
+- Match confidence words to the evidence. Distinguish independently checked results from values reported by a solver or another external system.
+- Use `certified`, `proven`, and similar terms only when the implementation supports that exact guarantee.
+- Keep soundness and numerical strength conceptually separate. If a valid result can also become narrower or stronger, explain the safeguard without making conservative and tighter sound contradictory.
+- Preserve assumptions and caveats for negative results, fallbacks, timeouts, nonfinite values, and partial solutions.
+- Inspect every relevant execution path before turning a fallback into an absolute statement.
+- Do not imply that adjacent or correlated changes share one cause or guarantee.
+- Do not turn an incomplete PR summary into a publishable claim. Mark the working draft as blocked or omit the claim until its material facts are verified.
+
+## Scope performance evidence
+
+When the notes include measured performance claims:
+
+- State the workload, mode or configuration, comparison basis, and denominator needed to interpret the result.
+- Say explicitly when measurements came from separate runs.
+- Map every number to the change and metric it supports.
+- Preserve comparable-sample conditions when totals exclude some cases.
+- Prefer familiar aggregate terms and short phrases over internal report labels or stacked modifiers.
+- Use enough precision to support the claim without carrying unnecessary digits into prose.
+- Report measurements as evidence from the measured setup, not as universal performance guarantees.
+
+## Cut detail that does not help release readers
+
+- Describe behavior, compatibility, migration needs, safeguards, and measured outcomes before implementation detail.
+- Summarize routine operational defenses as safety or publishing safeguards unless a specific guard changes how readers use the tool.
+- Omit implementation seams, internal refactors, and maintainer-only housekeeping unless they materially affect supported use or contribution workflow.
+- Keep a private change inventory so every omission is deliberate.
+- Remove redundant modifiers, repeated requirements, and phrases that restate a heading.
+- Prefer one clear sentence to a list of low-level safeguards or schema fields.
+
+## Minimal template
+
+Use sentence-case headings and omit empty sections.
+
+```markdown
+@JuliaRegistrator register
+
+Release notes:
+
+## <Purpose-based section>
+
+- <Goal or user-visible outcome>. <Essential mechanism, scope, or evidence>. (#<pr>)
+
+_AI collaboration: co-produced with Codex (OpenAI)._
+```
+
+## Final review
+
+Before approval, confirm:
+
+- every change in the release range was researched and either represented or deliberately omitted;
+- every bullet opens with its purpose or user-visible outcome;
+- combined bullets map each PR to its change immediately;
+- unfamiliar terms, acronyms, actors, and scopes are introduced;
+- each section reflects the purpose of its bullets;
+- safety and negative-result claims, when present, retain their assumptions and caveats;
+- performance claims, when present, preserve the experimental scope needed to interpret them;
+- unrelated work is not grouped under one claimed goal;
+- operational trivia and redundant wording are gone;
+- no provisional or unverified claim remains in copy-ready text;
+- review depth matches the release, with risky claims independently checked;
+- the Registrator marker, release-note label, PR references, and disclosure are intact.

--- a/.agents/skills/cut-release/references/release-notes-style.md
+++ b/.agents/skills/cut-release/references/release-notes-style.md
@@ -1,6 +1,8 @@
 # MIPVerify release-note style
 
-Use these rules when drafting, revising, or approving release notes. Prefer the shortest wording that preserves the user-visible behavior, compatibility boundary, safety caveat, and measurement scope.
+Use these rules when drafting, revising, or approving release notes. Prefer the shortest wording
+that preserves the user-visible behavior, compatibility boundary, safety caveat, and measurement
+scope.
 
 ## Lead with the purpose
 
@@ -12,57 +14,77 @@ Useful patterns include:
 - `<Goal> by <essential mechanism>.`
 - `<User-visible change>. <Important scope, migration, or evidence>.`
 
-Avoid opening with a PR number, schema operation, or implementation detail when the reader first needs the reason for the change.
+Avoid opening with a PR number, schema operation, or implementation detail when the reader first
+needs the reason for the change.
 
-When a bullet combines distinct PRs, map each PR to its change in the first sentence. Do not make readers reconstruct that mapping from the references at the end.
+When a bullet combines distinct PRs, map each PR to its change in the first sentence. Do not make
+readers reconstruct that mapping from the references at the end.
 
 ## Organize by purpose
 
 - Combine PRs only when they contribute to one reader-facing outcome.
 - Split changes that merely share a file, workflow, dependency, or implementation area.
 - Split a single PR across bullets when it contains changes with different purposes.
-- Place a change according to what it means to users: compatibility, behavior, correctness, performance, tooling, tests, CI, or maintenance.
-- Distinguish public breaking changes from versioned internal artifacts used only by repository tooling.
+- Place a change according to what it means to users: compatibility, behavior, correctness,
+  performance, tooling, tests, CI, or maintenance.
+- Distinguish public breaking changes from versioned internal artifacts used only by repository
+  tooling.
 
-Possible section names include `Breaking changes`, `New features`, `Correctness and performance`, `Benchmark tooling`, `Examples, tests, and CI`, and `Dependency compatibility`. Use only the sections justified by the current release. Rename or split them when that makes the grouping clearer.
+Possible section names include `Breaking changes`, `New features`, `Correctness and performance`,
+`Benchmark tooling`, `Examples, tests, and CI`, and `Dependency compatibility`. Use only the
+sections justified by the current release. Rename or split them when that makes the grouping
+clearer.
 
 ## Introduce terms, actors, and scope
 
 - Define unfamiliar domain terms before using their shorthand or result-field names.
 - Expand acronyms on first use unless they are already established in the notes.
-- Name the affected command, test set, workflow, API, or user group. Avoid vague labels whose actor or scope is unclear.
+- Name the affected command, test set, workflow, API, or user group. Avoid vague labels whose actor
+  or scope is unclear.
 - Put limiting words such as `only` next to the thing they limit.
-- Prefer plain descriptions to internal metric, schema, or implementation labels when the public meaning is the same.
+- Prefer plain descriptions to internal metric, schema, or implementation labels when the public
+  meaning is the same.
 
 ## Calibrate technical claims
 
 Apply the detailed checks below when the release makes correctness or solver-result claims:
 
-- Match confidence words to the evidence. Distinguish independently checked results from values reported by a solver or another external system.
-- Use `certified`, `proven`, and similar terms only when the implementation supports that exact guarantee.
-- Keep soundness and numerical strength conceptually separate. If a valid result can also become narrower or stronger, explain the safeguard without making conservative and tighter sound contradictory.
-- Preserve assumptions and caveats for negative results, fallbacks, timeouts, nonfinite values, and partial solutions.
+- Match confidence words to the evidence. Distinguish independently checked results from values
+  reported by a solver or another external system.
+- Use `certified`, `proven`, and similar terms only when the implementation supports that exact
+  guarantee.
+- Keep soundness and numerical strength conceptually separate. If a valid result can also become
+  narrower or stronger, explain the safeguard without making conservative and tighter sound
+  contradictory.
+- Preserve assumptions and caveats for negative results, fallbacks, timeouts, nonfinite values, and
+  partial solutions.
 - Inspect every relevant execution path before turning a fallback into an absolute statement.
 - Do not imply that adjacent or correlated changes share one cause or guarantee.
-- Do not turn an incomplete PR summary into a publishable claim. Mark the working draft as blocked or omit the claim until its material facts are verified.
+- Do not turn an incomplete PR summary into a publishable claim. Mark the working draft as blocked
+  or omit the claim until its material facts are verified.
 
 ## Scope performance evidence
 
 When the notes include measured performance claims:
 
-- State the workload, mode or configuration, comparison basis, and denominator needed to interpret the result.
+- State the workload, mode or configuration, comparison basis, and denominator needed to interpret
+  the result.
 - Say explicitly when measurements came from separate runs.
 - Map every number to the change and metric it supports.
 - Preserve comparable-sample conditions when totals exclude some cases.
-- Prefer familiar aggregate terms and short phrases over internal report labels or stacked modifiers.
+- Prefer familiar aggregate terms and short phrases over internal report labels or stacked
+  modifiers.
 - Use enough precision to support the claim without carrying unnecessary digits into prose.
 - Report measurements as evidence from the measured setup, not as universal performance guarantees.
 
 ## Cut detail that does not help release readers
 
-- Describe behavior, compatibility, migration needs, safeguards, and measured outcomes before implementation detail.
-- Summarize routine operational defenses as safety or publishing safeguards unless a specific guard changes how readers use the tool.
-- Omit implementation seams, internal refactors, and maintainer-only housekeeping unless they materially affect supported use or contribution workflow.
+- Describe behavior, compatibility, migration needs, safeguards, and measured outcomes before
+  implementation detail.
+- Summarize routine operational defenses as safety or publishing safeguards unless a specific guard
+  changes how readers use the tool.
+- Omit implementation seams, internal refactors, and maintainer-only housekeeping unless they
+  materially affect supported use or contribution workflow.
 - Keep a private change inventory so every omission is deliberate.
 - Remove redundant modifiers, repeated requirements, and phrases that restate a heading.
 - Prefer one clear sentence to a list of low-level safeguards or schema fields.


### PR DESCRIPTION
Cutting a MIPVerify release crosses several stateful handoffs: the version bump merges before
JuliaRegistrator opens a package-registry PR in Julia's General registry, and General must merge
before TagBot publishes the matching tag and GitHub release. If work resumes partway through,
repeating a step can create duplicate artifacts, while the reasoning behind version and release-note
choices is easy to lose.

This PR adds a repository-specific Codex `$cut-release` skill that instructs Codex to:

- reconstruct the live release state by comparing versions and commit IDs (SHAs) across the release
  PR, `Project.toml`, registration request, General PR, tag, and GitHub release, then resume from
  the first unfinished gate and perform only the gates the user authorized;
- inventory every first-parent change since the previous tag, research the implementation, tests,
  and evidence, guide version selection from the actual change set, and keep the release PR narrow;
- write purpose-first release notes from that inventory, record deliberate omissions, and preserve
  compatibility and fallback caveats and the scope of correctness and performance evidence; and
- require current CI before merge, register the merged commit, leave healthy General and TagBot
  automation alone, and verify the published tag and rendered release before reporting completion.

## Scope

This changes only repository-local agent instructions, a release-note style reference, and skill UI
metadata. It does not change MIPVerify code, its public API or compatibility, or release automation.
The guidance assumes the repository's current release setup. All write steps remain user-authorized,
and manual registry or tagging fallback needs explicit approval.

## Validation

- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/cut-release`
  passed (`Skill is valid!`). This validator checks the `SKILL.md` frontmatter.
- `git diff --check 9449e59..91b57da`
- At head `91b57da`, a read-only forward test of a hypothetical v0.8.0 release selected v0.9.0
  for new public functionality, retained the feature, dependency-compatibility change, both caching
  changes, and CI-only commit in the working inventory, rejected an unscoped `25% faster` claim,
  deliberately omitted CI-only housekeeping from the release notes, and stopped after drafting
  because no write gate was authorized. Missing PR references and verified API and compatibility
  details prevented a literal copy-ready draft. It did not exercise a live release or bot
  interaction.
- [GitHub Actions run 29640222520](https://github.com/vtjeng/MIPVerify.jl/actions/runs/29640222520)
  passed all 14 jobs on merge commit `3e01e50`, built from base `9449e59` and head
  `91b57da`, including Markdown and YAML formatting.

_AI collaboration: co-produced with Codex (OpenAI)._
