### PR TITLE
Keep Prettier out of vendored and throwaway copies

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+# Prettier does not read .gitignore, so vendored and throwaway copies have to be
+# listed again here or a whole-tree `prettier --check` reports files that are not
+# part of the repository.
+.claude/worktrees/
+**/.uv-cache/
+**/.venv/


### PR DESCRIPTION
`scripts/format.sh` runs `prettier --write "**/*.{md,yaml}"` across the whole tree, and Prettier does not read `.gitignore`. That puts Markdown and YAML under `benchmarks/analysis/.uv-cache/` and `.claude/worktrees/` in scope, so a formatting run can rewrite files in uv's package cache or inside an agent worktree.

Adds a `.prettierignore` covering `.claude/worktrees/`, `**/.uv-cache/`, and `**/.venv/`.

**Scope:** this is hardening, not a bug fix. Under the pinned Prettier 3.9.5, `--list-different` over the whole tree reports zero files both with and without this change, so nothing in the repository changes today. It only matters when a vendored or throwaway copy contains non-conforming Markdown or YAML.

**Verification:** `npx prettier@3.9.5 --list-different '**/*.{md,yaml}'` returns nothing before and after. `format-check-prettier` is unaffected — a CI checkout contains none of these directories.

Found while auditing why a local `PreToolUse` hook was reporting Prettier failures on every commit. The actual cause was unrelated (a stale Prettier 3.1.1 in a home-directory `node_modules` shadowing every project); this was a side observation.

_AI collaboration: co-produced with Claude Code (Anthropic)._
