### PR TITLE
Let Renovate track the pinned formatter and linter versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -220,6 +220,7 @@ jobs:
         uses: astral-sh/ruff-action@v4.1.0
         with:
           # Keep this version in sync with scripts/format.sh.
+          # renovate: datasource=pypi depName=ruff
           version: "0.15.21"
           args: "format --check --diff"
           src: "benchmarks/analysis/"
@@ -350,6 +351,7 @@ jobs:
           # Keep this version in sync with scripts/format.sh. Without a pin, the action
           # installs the latest Prettier, and new releases change formatting rules and
           # break CI on unchanged files.
+          # renovate: datasource=npm depName=prettier
           prettier_version: "3.9.5"
           prettier_options: --check **/*.{md,yaml}
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Formatter and linter versions pinned at their call site. Each pin carries a `# renovate:` comment naming its datasource, so the same manager handles the shell script and the workflow.",
+      "managerFilePatterns": [
+        "/^scripts/format\\.sh$/",
+        "/^\\.github/workflows/CI\\.yml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+[^\\n]*?@(?<currentValue>\\d[^\\s\"']+)",
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+[^\\n]*?version=?:? ?\"(?<currentValue>\\d[^\"]+)\""
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "JuliaFormatter has no Renovate datasource for the Julia General registry, so it is tracked by GitHub tag, which carries a leading `v`.",
+      "matchDepNames": ["JuliaEditorSupport/JuliaFormatter.jl"],
+      "extractVersion": "^v(?<version>.+)$"
+    }
+  ]
+}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -18,6 +18,7 @@ fi
   julia -e '
     using Pkg;
     Pkg.activate(tempname());
+    # renovate: datasource=github-tags depName=JuliaEditorSupport/JuliaFormatter.jl
     Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.2"));
     using JuliaFormatter;
     format(".", verbose=true)
@@ -32,6 +33,7 @@ fi
 # Format benchmark analysis Python with the same pinned Ruff version that CI uses
 # (see format-check-python in .github/workflows/CI.yml).
 if command -v uvx > /dev/null; then
+  # renovate: datasource=pypi depName=ruff
   (cd "${repo_root}" && uvx ruff@0.15.21 format benchmarks/analysis/)
 else
   echo "WARNING: uvx not found; skipping Ruff formatting of Python files." >&2
@@ -40,6 +42,7 @@ fi
 # Format Markdown and YAML with the same pinned Prettier version that CI uses
 # (see format-check-prettier in .github/workflows/CI.yml).
 if command -v npx > /dev/null; then
+  # renovate: datasource=npm depName=prettier
   (cd "${repo_root}" && npx --yes prettier@3.9.5 --write "**/*.{md,yaml}")
 else
   echo "WARNING: npx not found; skipping Prettier formatting of Markdown and YAML files." >&2


### PR DESCRIPTION
Adds a Renovate config so the pinned formatter and linter versions stay current without anyone remembering to bump them.

### Why

`scripts/format.sh` pins three tools at their call sites, and two of those versions are duplicated in `CI.yml` under a comment asking whoever edits one to remember the other. Nothing enforces that, and all three pins are now behind the current release:

| Tool | Pinned | Current |
| --- | --- | --- |
| Prettier | 3.9.5 | 3.9.6 |
| Ruff | 0.15.21 | 0.16.0 |
| JuliaFormatter | 1.0.2 | 2.11.4 |

The Current column is the latest version available when this PR was opened, read from npm for Prettier, PyPI for Ruff, and GitHub tags for JuliaFormatter.

### How

`renovate.json` defines one custom manager, driven by a `# renovate:` comment above each pin. Each comment names the pin's datasource: the place Renovate looks up available versions for that tool. The manager reads those comments in both `scripts/format.sh` and `CI.yml`, and a bump PR updates every occurrence of a version together. That is what the "keep this in sync" comments were asking a human to do.

The `config:recommended` preset also enables Renovate's built-in `github-actions` manager, which picks up the `uses:` action pins in all four workflow files. CompatHelper continues to handle Julia package compat bounds; this PR does not touch `Project.toml`.

JuliaFormatter is tracked by GitHub tag, because Renovate has no datasource for the Julia General registry. The `extractVersion` rule strips the leading `v` from each tag.

### Verification

- `renovate-config-validator` passes. As a control, the same validator rejects a copy of this `renovate.json` with a bogus key (`totallyNotAKey`) added, reporting `Invalid configuration option`.
- `renovate --platform=local --dry-run=extract` extracts `prettier @ 3.9.5`, `ruff @ 0.15.21`, and `JuliaEditorSupport/JuliaFormatter.jl @ 1.0.2` from the custom manager. The PR types below follow from the version table above.
- `bash -n scripts/format.sh` passes, and `julia -e` parses the marker comment that sits inside the Julia program, since both bash and Julia use `#` for comments.
- The dry run exercised extraction only: `--dry-run=extract` stops before looking up available versions. It also logged a GitHub API rate-limit warning, because no token was supplied. The Current column above was read from npm for Prettier, PyPI for Ruff, and GitHub tags on `JuliaEditorSupport/JuliaFormatter.jl`; Renovate did not confirm those versions.

### What to expect once the Renovate app is installed

The Renovate GitHub App is now installed on this repository, and it has opened onboarding PR #251, which proposes a `renovate.json` containing only `extends: ["config:recommended"]`. This config includes that preset, so #251 can be closed rather than merged. Renovate reads its config from the default branch, so nothing here takes effect until this PR merges.

After that, expect a Dependency Dashboard issue, a patch PR for Prettier, a minor PR for Ruff, and a major PR for JuliaFormatter. The JuliaFormatter one will likely fail the "`JuliaFormatter.format` is a no-op" check, since 2.x reformats differently than 1.0.2. That PR needs the reformatted files committed alongside the bump.

The preset covers more than the action pins: onboarding PR #251 reports that Renovate also reads `benchmarks/analysis/pyproject.toml` through its pep621 manager, and it treats the `version: "0.11.2"` input to `astral-sh/setup-uv` as `astral-sh/uv`, for which 0.11.32 is available. Expect PRs for those too. The pyproject dependencies are `>=` floors that already admit current releases, so that manager should stay quiet.

_AI collaboration: co-produced with Claude Code (Anthropic)._

