### PR TITLE
Declare least-privilege permissions for every workflow job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,12 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# Least privilege by default: with this block present, every scope not listed is
+# set to none, and jobs needing more declare it themselves (see `test` below, and
+# nightly-benchmark.yml, which pushes results).
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
@@ -114,6 +120,11 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      # Stated explicitly because this is the one job that publishes: Documenter
+      # deploys through DOCUMENTER_KEY over SSH (docs/make.jl calls deploydocs with
+      # no token config), so GITHUB_TOKEN never needs write access here.
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,6 +14,11 @@ jobs:
   # above provides alternatives if we want to do this 'right'.
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      # Pushes the compat branch and opens the pull request. Every other scope is
+      # none, which the default write-all token did not give us.
+      contents: write
+      pull-requests: write
     steps:
       - name: "Add the General registry via Git"
         run: |

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -10,6 +10,12 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      # Creates the tag and the GitHub release.
+      contents: write
+      # TagBot builds release notes from merged pull requests and closed issues.
+      issues: read
+      pull-requests: read
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:


### PR DESCRIPTION
First of a few changes to reduce what CI can do if a third-party action turns out to be malicious. This one touches no action versions and no third-party code.

### Problem

The repository's default `GITHUB_TOKEN` permission is **write**, and `can_approve_pull_request_reviews` is true. Only `test` in CI.yml and nightly-benchmark.yml declared a `permissions` block, so every other job received that write-scoped token — including jobs whose whole purpose is to read and check files. `creyD/prettier_action`, `astral-sh/ruff-action`, and `codecov-action` all execute inside those jobs.

### Effective permissions after this change

| Workflow / job | Before | After |
| --- | --- | --- |
| CI.yml workflow default | repo default (write-all) | `contents: read` |
| CI.yml `test` | `contents: read`, `id-token: write` | unchanged |
| CI.yml `docs` | repo default (write-all) | `contents: read` (explicit) |
| CI.yml `format-check-julia`, `format-check-python`, `format-check-prettier`, `benchmark-tests`, `benchmark-analysis-tests`, `notebook-tests`, `lint-workflows` | repo default (write-all) | `contents: read` (inherited) |
| CompatHelper | repo default (write-all) | `contents: write`, `pull-requests: write` |
| TagBot | repo default (write-all) | `contents: write`, `issues: read`, `pull-requests: read` |
| nightly-benchmark | `contents: write` | unchanged |

Declaring any block sets every unlisted scope to none, so CompatHelper and TagBot lose write access to actions, checks, deployments, packages, pages, statuses, and security events even though they keep `contents: write`.

### The one job to watch

`docs` is the only job that publishes, and **this PR's own CI cannot prove the change is safe for it** — `deploydocs` skips deployment on pull requests, so the deploy path first runs on the next push to master. The reasoning for `contents: read`: `docs/make.jl` calls `deploydocs(repo = "github.com/vtjeng/MIPVerify.jl.git")` with no token configuration, and `DOCUMENTER_KEY` is set in the job environment, so Documenter authenticates over SSH rather than with `GITHUB_TOKEN`. If a master run fails at the deploy step, adding `contents: write` to that job restores the old behavior.

TagBot and CompatHelper are also unexercised by this PR: both are schedule- or comment-triggered. TagBot's next real run is the next release.

### Verification

All four workflow files parse as YAML, and the effective per-job permissions were enumerated from the parsed files to produce the table above. `lint-workflows` (actionlint) runs on this PR and covers workflow-syntax errors.

### Next

Once this is merged and a master run confirms the docs deploy, the repository default can be flipped from write to read, so a workflow added later cannot silently get a write token. That is a repository setting, not a file change.

_AI collaboration: co-produced with Claude Code (Anthropic)._
