### PR TITLE
Withhold write-capable credentials from jobs that never use them

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,6 +71,10 @@ jobs:
             primary: true
     steps:
       - uses: actions/checkout@v7
+        # No step here pushes, so the token does not need to be left in
+        # .git/config where a third-party action could read it.
+        with:
+          persist-credentials: false
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
@@ -179,7 +183,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # I created a `DOCUMENTER_KEY` secret, via
           # https://discourse.julialang.org/t/easy-workflow-file-for-setting-up-github-actions-ci-for-your-julia-package/49765/46
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          #
+          # This is an SSH deploy key with push access, so `permissions:` does not
+          # constrain it. `deploydocs` never deploys from a pull request, so withhold
+          # the key there rather than placing it in the environment of a job that runs
+          # third-party actions and instantiates the docs package environment. Every
+          # other event keeps it, which covers the master pushes and tags that deploy.
+          DOCUMENTER_KEY:
+            ${{ github.event_name != 'pull_request' && secrets.DOCUMENTER_KEY || '' }}
       - name: Save documentation Julia package state
         if:
           ${{ success() && steps.docs-final-key.outputs.key !=
@@ -200,6 +211,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
@@ -227,6 +240,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: "Verify that Ruff does not find any code style issues."
         uses: astral-sh/ruff-action@v4.1.0
         with:
@@ -242,6 +257,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
@@ -261,6 +278,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: julia-actions/setup-julia@v3
         id: setup-julia
         with:
@@ -328,6 +347,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
@@ -355,6 +376,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: "Verify that Prettier does not find any code style issues."
         uses: creyD/prettier_action@v4.3
         with:
@@ -369,6 +392,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: "Verify that actionlint finds no issues in .github/workflows."
         # Pinned so new lint rules cannot break CI on unchanged files. The image
         # bundles shellcheck and pyflakes, so `run:` blocks are checked too.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -185,10 +185,11 @@ jobs:
           # https://discourse.julialang.org/t/easy-workflow-file-for-setting-up-github-actions-ci-for-your-julia-package/49765/46
           #
           # This is an SSH deploy key with push access, so `permissions:` does not
-          # constrain it. `deploydocs` never deploys from a pull request, so withhold
-          # the key there rather than placing it in the environment of a job that runs
-          # third-party actions and instantiates the docs package environment. Every
-          # other event keeps it, which covers the master pushes and tags that deploy.
+          # constrain it. `deploydocs` never deploys from a pull request, so the key is
+          # withheld there: on those runs it would sit unused in the environment of a
+          # job that instantiates the docs package environment and runs four actions
+          # this repository does not own. Every other event keeps it, which covers the
+          # pushes and tags that deploy.
           DOCUMENTER_KEY:
             ${{ github.event_name != 'pull_request' && secrets.DOCUMENTER_KEY || '' }}
       - name: Save documentation Julia package state

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -28,6 +28,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: master
+          # This job holds a `contents: write` token, and the steps below run a long
+          # benchmark and instantiate a package environment before reaching the push.
+          # The push uses its own clone of `benchmark-results` with an explicit token
+          # URL, so nothing here needs credentials left in .git/config.
+          persist-credentials: false
 
       - uses: julia-actions/setup-julia@v3
         with:


### PR DESCRIPTION
#252 scoped `GITHUB_TOKEN`. This PR withholds `DOCUMENTER_KEY` from pull request runs and sets `persist-credentials: false` in every job except the docs deploy. A `permissions:` block controls neither credential, which is why #252 left them alone. No action versions change.

### Problem

**`DOCUMENTER_KEY`** is an SSH deploy key with push access to this repository, so `permissions:` has no effect on it. `CI.yml` set it on the docs job's `make.jl` step for every event. `docs/make.jl` calls `deploydocs`, which never deploys from a pull request. So on every PR run the key sat unused in the environment of a job that instantiates the docs package environment and runs four actions this repository does not own, one of them community-maintained. Fork PRs receive no secrets, but this repository's PRs are same-repo branches, which do.

**`persist-credentials`** still defaults to `true` in `actions/checkout@v7`, so every job wrote its token into `.git/config`, where any later step can read it. After #252 that token is read-only in most jobs, which makes this the smaller of the two changes. The exception is the nightly benchmark, which holds `contents: write`.

### Changes

| Workflow / job | Change |
| --- | --- |
| `CI.yml` docs | `DOCUMENTER_KEY` withheld when `github.event_name == 'pull_request'`; unchanged for every other event |
| `CI.yml`, all jobs except docs | `persist-credentials: false` |
| `nightly-benchmark.yml` benchmark | `persist-credentials: false` |

Setting the key only on the events that deploy (pushes and tags) was rejected as the more aggressive option. `!= 'pull_request'` removes the key only where deployment is already known not to happen, so no deploying event can lose it by omission.

The docs job deliberately keeps credential persistence. It is the one job that deploys, and its token is read-only as of #252, so little is exposed. It is also the one path this PR's own CI cannot exercise end to end, so the job gets the `DOCUMENTER_KEY` change alone. Leaving `persist-credentials` at its default there keeps the untested surface as narrow as possible.

The opt-out matters most in the nightly benchmark. That job holds a write token across a ~hours-long benchmark and a `Pkg.instantiate()`, and reaches the push only at the end. The push is unaffected: it clones `benchmark-results` into `/tmp` with its own `x-access-token:` URL and never pushes from the workspace.

### Verification

- Both workflow files parse as YAML, and the effective `persist-credentials` value was read per job from the parsed files to produce the table above. `lint-workflows` (actionlint) runs on this PR.
- `persist-credentials` still defaults to `true` in `actions/checkout@v7`. The default was read from the action's own `action.yml` at the `v7` tag.
- The `DOCUMENTER_KEY` expression resolves to `${{ github.event_name != 'pull_request' && secrets.DOCUMENTER_KEY || '' }}`: the key on `push`, tag, and `workflow_dispatch`, empty on pull requests. Those three are `CI.yml`'s only triggers besides `pull_request`.
- This PR's own CI covers `persist-credentials: false` across the eight changed `CI.yml` jobs, and the docs job running to completion with the key absent.
- Baseline for the deploy path: #252's merge produced a `gh-pages` commit ("build based on `e83e6b6`"). Documenter therefore deploys over SSH with `contents: read`.

### Not exercised here

The deploy itself is untested, for the same structural reason as #252: `deploydocs` skips on pull requests, so the first run with this expression is the next push to master. The failure mode is narrow. If the key were withheld on an event that deploys, Documenter would fail to authenticate; only `pull_request` is affected, and on that event `deploydocs` returns before it authenticates.

`nightly-benchmark.yml` runs on a 6 AM UTC schedule, so its change lands there first unless the workflow is dispatched manually, which its `workflow_dispatch` trigger allows.

### Deferred

- Flip the repository default `GITHUB_TOKEN` permission from write to read. This is a repository setting; no file change is involved. The docs deploy that gated it has now been confirmed. Every job in all four workflows declares the scopes it needs, and an explicit `permissions:` block still grants above the repository default, so nothing loses access.
- `can_approve_pull_request_reviews` stays enabled, revising what this list said earlier. The same setting governs pull request creation, which CompatHelper uses to open its compat pull requests through `GITHUB_TOKEN`. Master requires no approving reviews, so the approval capability unlocks nothing that is not already available, and disabling it would cost a working bot for no gain.
- Pin actions by commit SHA; the current pins are mutable tags. Best done after #250, so Renovate maintains the digests.
- Confine the nightly benchmark's write token to a push-only job that runs no third-party code.

_AI collaboration: co-produced with Claude Code (Anthropic)._
