### PR TITLE
Run Prettier directly instead of through creyD/prettier_action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -381,14 +381,15 @@ jobs:
         with:
           persist-credentials: false
       - name: "Verify that Prettier does not find any code style issues."
-        uses: creyD/prettier_action@v4.3
-        with:
-          # Keep this version in sync with scripts/format.sh. Without a pin, the action
-          # installs the latest Prettier, and new releases change formatting rules and
-          # break CI on unchanged files.
-          # renovate: datasource=npm depName=prettier
-          prettier_version: "3.9.5"
-          prettier_options: --check **/*.{md,yaml}
+        # Keep this version in sync with scripts/format.sh. Without a pin, npx
+        # resolves the latest Prettier, and new releases change formatting rules and
+        # break CI on unchanged files.
+        #
+        # The glob is quoted so that Prettier expands it, matching scripts/format.sh.
+        # Unquoted, the shell expands it first, and without `globstar` its `**` acts
+        # as a single `*`, which reaches only Markdown one directory deep.
+        # renovate: datasource=npm depName=prettier
+        run: npx --yes prettier@3.9.5 --check "**/*.{md,yaml}"
 
   lint-workflows:
     name: "Lint GitHub Actions Workflows"

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ Manifest.toml
 # .claude/skills/, .claude/agents/) stays trackable.
 .claude/worktrees/
 .claude/settings.local.json
+
+# Python subproject caches. benchmarks/analysis/.gitignore already lists these for
+# Git's purposes. They are repeated here because Prettier reads the root .gitignore
+# and does not read nested ones, and a whole-tree `prettier --check` would otherwise
+# report files that are not part of the repository.
+**/.venv/
+**/.uv-cache/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-# Prettier does not read .gitignore, so vendored and throwaway copies have to be
-# listed again here or a whole-tree `prettier --check` reports files that are not
-# part of the repository.
-.claude/worktrees/
-**/.uv-cache/
-**/.venv/


### PR DESCRIPTION
Removes the last third-party action from CI, a port of vtjeng/vtjeng.github.io#64.

### Run Prettier directly

`creyD/prettier_action@v4.3` ran `prettier <options>` with the version given as `prettier_version`. The replacement is that call with the pin at the call site:

```yaml
# renovate: datasource=npm depName=prettier
run: npx --yes prettier@3.9.5 --check "**/*.{md,yaml}"
```

Nothing beyond `actions/checkout` runs third-party code in this job now. The step uses the runner's preinstalled Node with no `actions/setup-node` pin, since the Node version is not a formatting input.

`renovate.json` needs no change: the custom manager added in #250 already matches the `@version` form, which `scripts/format.sh` uses to pin Prettier and Ruff. Its `version: "..."` match string stays in use for the Ruff action.

### Glob quoting

The glob is now quoted, so Prettier expands it. The action passed `--check **/*.{md,yaml}` through a shell, where `**` without `globstar` acts as a single `*`: `**/*.md` reached only the 2 of 22 tracked Markdown files that sit one directory deep, and 22 of 22 are checked now. `**/*.yaml` matched nothing at that depth, so Prettier got it literally and checked both YAML files before and after (2 of 2). `scripts/format.sh` has always quoted the glob, so the Markdown that CI missed is already formatted.

### Consolidate the ignore rules

Prettier reads the root `.gitignore` by default, contrary to `.prettierignore`'s comment, so its `.claude/worktrees/` entry duplicated a rule the root `.gitignore` already had. The other two entries were load-bearing: `.venv/` and `.uv-cache/` are ignored by `benchmarks/analysis/.gitignore`, which Prettier does not read. This moves them to the root `.gitignore` and deletes `.prettierignore`, so one ignore file governs Prettier. The rules matter more than they did, since until the first commit the CI glob reached almost no Markdown.

### Verification

- Running the command above on a clean checkout of this branch prints "All matched files use Prettier code style!".
- `bash -c 'set -- **/*.md; printf "%s\n" "$@"'` prints `benchmarks/README.md` and `benchmarks/REPORT_TEMPLATE.md`; `git ls-files '*.md'` counts 22.
- `prettier --list-different` reports an identical control file at the repository root but skips a badly formatted probe under `deps/`, which `git check-ignore` reports as ignored by the root `.gitignore` and which `.prettierignore` never listed.
- With `.prettierignore` deleted, probes under `benchmarks/analysis/.venv/`, `benchmarks/analysis/.uv-cache/`, and `.claude/worktrees/` are skipped too.
- `Check Formatting (.md, .yaml)`, a required check, runs the new step on this PR.

_AI collaboration: co-produced with Claude Code (Anthropic)._
