### PR TITLE
Consolidate agent instructions into AGENTS.md and document formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 ## Formatting
 
-Run `./scripts/format.sh` before pushing; CONTRIBUTING.md covers the flags. It uses the tool
-versions pinned inside it, which are the versions CI checks.
+Run `./scripts/format.sh` before pushing. It uses the tool versions pinned inside it, which are the
+versions CI checks.
 
 ### Formatter version bumps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,13 @@ versions pinned inside it, which are the versions CI checks.
 
 ### Formatter version bumps
 
-Renovate bumps those pins. A `Check Formatting` failure on such a PR is expected: the new version
-reformats files the old one accepted.
+Renovate can bump formatter versions. A `Check Formatting` failure on such a PR is expected: the new
+version reformats files the old one accepted.
 
-Run `./scripts/format.sh` on the Renovate branch and commit the result there. The two halves cannot
-land separately, because the check runs `format.sh` with the version that same file pins. Review the
-reformat as a real diff, especially across a major version. Pushing marks the PR as edited and
-Renovate stops updating it, so merge promptly.
+Run `./scripts/format.sh` on the Renovate branch and commit the result there. The pin and the
+reformat have to land together, because the check runs `format.sh` with the version that same file
+pins. Review the reformat as a real diff, especially across a major version. Pushing marks the PR as
+edited and Renovate stops updating it, so merge promptly.
 
 ## Flaky CI failures
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,58 @@
 # Repository Agent Instructions
 
 - Work on a descriptive feature branch. Do not make changes or commits directly on `master`.
+
+## Formatting
+
+Run `./scripts/format.sh` before pushing. It formats the repository with the tool versions pinned
+inside it, which are the versions CI checks against. See CONTRIBUTING.md for the flags.
+
+### Formatter version bumps
+
+Renovate tracks those pins. When a bump makes `Check Formatting` fail, the new version is
+reformatting files the old one accepted. That is not flake, and not a reason to close the PR.
+
+1. Check out the Renovate branch, run `./scripts/format.sh`, and commit the result to that same
+   branch. The reformat cannot land on its own: the check runs `format.sh` with the version that
+   same file pins, so a reformat merged ahead of the bump would be reverted by the old version, and
+   the bump merged alone leaves the check red.
+2. Read the reformat commit as a real diff rather than trusting the tool, especially across a major
+   version. The full test matrix reruns on the pushed commit.
+3. Pushing to the branch marks the PR as edited, and Renovate stops updating it. Merge it promptly
+   rather than leaving it to collect later releases.
+
+If a reformat is broad and mechanical enough to bury authorship in `git blame`, add the merged
+commit's SHA to `.git-blame-ignore-revs` in a follow-up commit — the SHA does not exist until the
+merge. A squash commit that also carries a substantive change does not qualify, because ignoring it
+would hide that change from blame too.
+
+## Flaky CI failures
+
+When a CI job fails on a PR, read the failure log and classify it before rerunning. A failure in
+code or config the PR touches is not flake — debug it instead.
+
+For failures unrelated to the PR's changes:
+
+1. Search open issues titled "Flaky CI" for a matching signature (failing test case, error type,
+   crash stack site). Read resolved versions from the job log rather than from the check name —
+   distinct matrix selectors can resolve to the same underlying version.
+2. If an issue matches, the failure is a known flake. Append a row to its "Occurrences" table (date,
+   branch or PR with short SHA, linked job name), add a comment with the specifics — job link,
+   observed vs expected values or crash site, dependency versions from the log — and update the
+   issue title if the new occurrence invalidates a qualifier in it. Then rerun the failed jobs.
+3. If nothing matches, rerun first: `gh run rerun <run-id> --failed` (the run must be completed).
+   Only a passing rerun verifies the failure as flake — then open a new issue titled "Flaky CI:
+   <signature>" with the failure details, versions, a job link, and an "Occurrences" table ending
+   with "Append new occurrences to this table."
+4. If the same leg fails twice in a row on one PR, stop rerunning and report it — repetition
+   suggests a real regression, not flake.
+
+## Performance log
+
+When a PR changes verification (solve) or CI performance, append a row to the matching section of
+PERFORMANCE.md in the same PR, with the measured impact and an evidence link.
+
+## Paired benchmark report comments
+
+Before writing or editing a paired benchmark report PR comment, read benchmarks/REPORT_TEMPLATE.md
+and follow it exactly, including its section order.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,6 @@ reformatting files the old one accepted. That is not flake, and not a reason to 
 3. Pushing to the branch marks the PR as edited, and Renovate stops updating it. Merge it promptly
    rather than leaving it to collect later releases.
 
-If a reformat is broad and mechanical enough to bury authorship in `git blame`, add the merged
-commit's SHA to `.git-blame-ignore-revs` in a follow-up commit — the SHA does not exist until the
-merge. A squash commit that also carries a substantive change does not qualify, because ignoring it
-would hide that change from blame too.
-
 ## Flaky CI failures
 
 When a CI job fails on a PR, read the failure log and classify it before rerunning. A failure in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,22 +4,18 @@
 
 ## Formatting
 
-Run `./scripts/format.sh` before pushing. It formats the repository with the tool versions pinned
-inside it, which are the versions CI checks against. See CONTRIBUTING.md for the flags.
+Run `./scripts/format.sh` before pushing; CONTRIBUTING.md covers the flags. It uses the tool
+versions pinned inside it, which are the versions CI checks.
 
 ### Formatter version bumps
 
-Renovate tracks those pins. When a bump makes `Check Formatting` fail, the new version is
-reformatting files the old one accepted. That is not flake, and not a reason to close the PR.
+Renovate bumps those pins. A `Check Formatting` failure on such a PR means the new version reformats
+files the old one accepted — not flake.
 
-1. Check out the Renovate branch, run `./scripts/format.sh`, and commit the result to that same
-   branch. The reformat cannot land on its own: the check runs `format.sh` with the version that
-   same file pins, so a reformat merged ahead of the bump would be reverted by the old version, and
-   the bump merged alone leaves the check red.
-2. Read the reformat commit as a real diff rather than trusting the tool, especially across a major
-   version. The full test matrix reruns on the pushed commit.
-3. Pushing to the branch marks the PR as edited, and Renovate stops updating it. Merge it promptly
-   rather than leaving it to collect later releases.
+Run `./scripts/format.sh` on the Renovate branch and commit the result there. The two halves cannot
+land separately, because the check runs `format.sh` with the version that same file pins. Review the
+reformat as a real diff, especially across a major version. Pushing marks the PR as edited and
+Renovate stops updating it, so merge promptly.
 
 ## Flaky CI failures
 
@@ -29,18 +25,17 @@ code or config the PR touches is not flake — debug it instead.
 For failures unrelated to the PR's changes:
 
 1. Search open issues titled "Flaky CI" for a matching signature (failing test case, error type,
-   crash stack site). Read resolved versions from the job log rather than from the check name —
-   distinct matrix selectors can resolve to the same underlying version.
-2. If an issue matches, the failure is a known flake. Append a row to its "Occurrences" table (date,
-   branch or PR with short SHA, linked job name), add a comment with the specifics — job link,
-   observed vs expected values or crash site, dependency versions from the log — and update the
-   issue title if the new occurrence invalidates a qualifier in it. Then rerun the failed jobs.
-3. If nothing matches, rerun first: `gh run rerun <run-id> --failed` (the run must be completed).
-   Only a passing rerun verifies the failure as flake — then open a new issue titled "Flaky CI:
-   <signature>" with the failure details, versions, a job link, and an "Occurrences" table ending
-   with "Append new occurrences to this table."
+   crash stack site). Read versions from the job log, not the check name — distinct matrix selectors
+   can resolve to the same version.
+2. On a match, it is a known flake: append a row to that issue's "Occurrences" table (date, branch
+   or PR with short SHA, linked job name), comment with the specifics (job link, observed vs
+   expected or crash site, versions from the log), and correct the issue title if the occurrence
+   invalidates a qualifier in it. Then rerun the failed jobs.
+3. With no match, rerun first: `gh run rerun <run-id> --failed` (the run must have completed). Only
+   a passing rerun confirms flake — then open "Flaky CI: <signature>" with the failure details,
+   versions, a job link, and an "Occurrences" table ending "Append new occurrences to this table."
 4. If the same leg fails twice in a row on one PR, stop rerunning and report it — repetition
-   suggests a real regression, not flake.
+   suggests a real regression.
 
 ## Performance log
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ versions pinned inside it, which are the versions CI checks.
 
 ### Formatter version bumps
 
-Renovate bumps those pins. A `Check Formatting` failure on such a PR means the new version reformats
-files the old one accepted — not flake.
+Renovate bumps those pins. A `Check Formatting` failure on such a PR is expected: the new version
+reformats files the old one accepted.
 
 Run `./scripts/format.sh` on the Renovate branch and commit the result there. The two halves cannot
 land separately, because the check runs `format.sh` with the version that same file pins. Review the
@@ -25,8 +25,8 @@ code or config the PR touches is not flake — debug it instead.
 For failures unrelated to the PR's changes:
 
 1. Search open issues titled "Flaky CI" for a matching signature (failing test case, error type,
-   crash stack site). Read versions from the job log, not the check name — distinct matrix selectors
-   can resolve to the same version.
+   crash stack site). Read versions from the job log. A check name records only the matrix selector,
+   so `Julia 1` and `Julia 1.12` can name the same underlying version.
 2. On a match, it is a known flake: append a row to that issue's "Occurrences" table (date, branch
    or PR with short SHA, linked job name), comment with the specifics (job link, observed vs
    expected or crash site, versions from the log), and correct the issue title if the occurrence

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ edited and Renovate stops updating it, so merge promptly.
 
 ## Flaky CI failures
 
-When a CI job fails on a PR, read the failure log and classify it before rerunning. A failure in
-code or config the PR touches is not flake — debug it instead.
+When a CI job fails on a PR, read the failure log and classify it before rerunning. If the failure
+is in code or config the PR touches, debug it rather than treating it as flake.
 
 For failures unrelated to the PR's changes:
 
@@ -32,10 +32,10 @@ For failures unrelated to the PR's changes:
    expected or crash site, versions from the log), and correct the issue title if the occurrence
    invalidates a qualifier in it. Then rerun the failed jobs.
 3. With no match, rerun first: `gh run rerun <run-id> --failed` (the run must have completed). Only
-   a passing rerun confirms flake — then open "Flaky CI: <signature>" with the failure details,
+   a passing rerun confirms flake. Then open "Flaky CI: <signature>" with the failure details,
    versions, a job link, and an "Occurrences" table ending "Append new occurrences to this table."
-4. If the same leg fails twice in a row on one PR, stop rerunning and report it — repetition
-   suggests a real regression.
+4. If the same leg fails twice in a row on one PR, stop rerunning and report it. Repetition suggests
+   a real regression.
 
 ## Performance log
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,32 +1,5 @@
 # CLAUDE.md
 
-## Flaky CI failures
+The repository's agent instructions live in AGENTS.md so that every tool reads the same file.
 
-When a CI job fails on a PR, read the failure log and classify it before rerunning. A failure in
-code or config the PR touches is not flake — debug it instead.
-
-For failures unrelated to the PR's changes:
-
-1. Search open issues titled "Flaky CI" for a matching signature (failing test case, error type,
-   crash stack site). Read resolved versions from the job log rather than from the check name —
-   distinct matrix selectors can resolve to the same underlying version.
-2. If an issue matches, the failure is a known flake. Append a row to its "Occurrences" table (date,
-   branch or PR with short SHA, linked job name), add a comment with the specifics — job link,
-   observed vs expected values or crash site, dependency versions from the log — and update the
-   issue title if the new occurrence invalidates a qualifier in it. Then rerun the failed jobs.
-3. If nothing matches, rerun first: `gh run rerun <run-id> --failed` (the run must be completed).
-   Only a passing rerun verifies the failure as flake — then open a new issue titled "Flaky CI:
-   <signature>" with the failure details, versions, a job link, and an "Occurrences" table ending
-   with "Append new occurrences to this table."
-4. If the same leg fails twice in a row on one PR, stop rerunning and report it — repetition
-   suggests a real regression, not flake.
-
-## Performance log
-
-When a PR changes verification (solve) or CI performance, append a row to the matching section of
-PERFORMANCE.md in the same PR, with the measured impact and an evidence link.
-
-## Paired benchmark report comments
-
-Before writing or editing a paired benchmark report PR comment, read benchmarks/REPORT_TEMPLATE.md
-and follow it exactly, including its section order.
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,10 +104,6 @@ and [Prettier](https://prettier.io/) for `.md` and `.yaml`.
 ./scripts/format.sh
 ```
 
-Ruff runs through `uvx` and Prettier through `npx`; if either is missing from your `PATH` the script
-warns and skips that step, so those files stay unformatted and CI catches them. Pass `--julia-only`
-to run JuliaFormatter alone.
-
 ## Contribution Types
 
 There are many ways to contribute to this package.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Ensure that your PR passes all required statuses.
 ### Formatting
 
 Run the format script before pushing. It formats the whole repository with the same tool versions
-that CI checks against — JuliaFormatter for `.jl`, [Ruff](https://docs.astral.sh/ruff/) for `.py`,
+that CI checks against: JuliaFormatter for `.jl`, [Ruff](https://docs.astral.sh/ruff/) for `.py`,
 and [Prettier](https://prettier.io/) for `.md` and `.yaml`.
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,20 @@ julia --project=test test/models.jl
 
 Ensure that your PR passes all required statuses.
 
+### Formatting
+
+Run the format script before pushing. It formats the whole repository with the same tool versions
+that CI checks against — JuliaFormatter for `.jl`, [Ruff](https://docs.astral.sh/ruff/) for `.py`,
+and [Prettier](https://prettier.io/) for `.md` and `.yaml`.
+
+```sh
+./scripts/format.sh
+```
+
+Ruff runs through `uvx` and Prettier through `npx`; if either is missing from your `PATH` the script
+warns and skips that step, so those files stay unformatted and CI catches them. Pass `--julia-only`
+to run JuliaFormatter alone.
+
 ## Contribution Types
 
 There are many ways to contribute to this package.


### PR DESCRIPTION
`AGENTS.md` (added in #213) and `CLAUDE.md` held disjoint instructions: Codex read only the branch rule, Claude Code read only flaky-CI triage, the performance log, and the benchmark report template. `AGENTS.md` is now the single source and `CLAUDE.md` imports it:

```markdown
@AGENTS.md
```

A pointer rather than a symlink, because CI checks out on `windows-latest`, where a checkout without symlink support materializes the symlink as a text file containing a path. Verified the import resolves: a fresh `claude -p` session quoted the benchmark-report sentence, which now exists only in `AGENTS.md`.

### Formatter version bumps

New `AGENTS.md` section, prompted by #263. When Renovate bumps a formatter pin and `Check Formatting` fails, the reformat has to be committed to that same PR — `format-check-julia` runs `./scripts/format.sh --julia-only`, so the check always uses the version that same file pins. A reformat merged ahead of the bump gets reverted by the old version; the bump merged alone leaves the check red.

### CONTRIBUTING.md

`scripts/format.sh` appeared in no `.md` file in the repo, so a red CI check was the only way to discover it. "Preparing your PR for review" now names the script, the three tools it pins, and the `uvx`/`npx` requirement for the Ruff and Prettier steps.

No behavior changes — documentation only.

_AI collaboration: co-produced with Claude Code (Anthropic)._