### PR TITLE
Let releases settle for 14 days before Renovate proposes them

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "14 days",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Renovate proposes releases the moment they appear. #263 adopted JuliaFormatter 2.11.5 seven minutes after publication, during a run of six releases in five days:

| version | published |
|---|---|
| v2.11.0 | 2026-07-21 12:38 |
| v2.11.1 | 2026-07-22 18:47 |
| v2.11.2 | 2026-07-23 10:08 |
| v2.11.3 | 2026-07-24 14:57 |
| v2.11.4 | 2026-07-24 16:17 |
| v2.11.5 | 2026-07-25 17:01 |

v2.11.5's notes say it fixes YASStyle indentation bugs that were regressions in v2.11.1, so that whole window was churn.

`minimumReleaseAge` makes a release wait before Renovate will propose it. `internalChecksFilter` already defaults to `strict`, so no branch or PR is created until the window clears — there is no pending PR to review.

Security updates are unaffected: the `vulnerabilityAlerts` defaults set `minimumReleaseAge` to `null`, so a CVE fix still opens immediately.

Applied to `vtjeng.github.io` in vtjeng/vtjeng.github.io#69.

_AI collaboration: co-produced with Claude Code (Anthropic)._